### PR TITLE
Add stateless game API endpoints with version locking

### DIFF
--- a/api/act.php
+++ b/api/act.php
@@ -1,0 +1,74 @@
+<?php
+// Apply an action to game state with optimistic locking.
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/update_game.php';
+
+header('Content-Type: application/json');
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!is_array($input)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'invalid json']);
+    exit;
+}
+
+$game_id = isset($input['game_id']) ? (int)$input['game_id'] : 0;
+$expected_version = isset($input['expected_version']) ? (int)$input['expected_version'] : -1;
+$action = $input['action'] ?? null;
+if ($game_id <= 0 || $expected_version < 0 || !is_array($action)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'missing fields']);
+    exit;
+}
+
+function db(): PDO {
+    $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
+    $pdo = new PDO($dsn);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    return $pdo;
+}
+
+function apply_action(array $state, array $action, array $rules): array {
+    // Placeholder: append action to log.
+    $state['log'][] = $action;
+    return $state;
+}
+
+$pdo = db();
+try {
+    $pdo->beginTransaction();
+    $stmt = $pdo->prepare('SELECT state_json, version, rules_json_snapshot FROM games WHERE id = ? FOR UPDATE');
+    $stmt->execute([$game_id]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$row) {
+        $pdo->rollBack();
+        http_response_code(404);
+        echo json_encode(['error' => 'game not found']);
+        exit;
+    }
+    if ((int)$row['version'] !== $expected_version) {
+        $pdo->rollBack();
+        http_response_code(409);
+        echo json_encode(['error' => 'version mismatch']);
+        exit;
+    }
+    $state = json_decode($row['state_json'], true);
+    $rules = json_decode($row['rules_json_snapshot'], true);
+    $new_state = apply_action($state, $action, $rules);
+    $new_state['version'] = $state['version'] + 1;
+    $update = $pdo->prepare('UPDATE games SET state_json = :state, version = version + 1 WHERE id = :id');
+    $update->execute([
+        ':state' => json_encode($new_state, JSON_UNESCAPED_UNICODE),
+        ':id' => $game_id,
+    ]);
+    $pdo->commit();
+    echo json_encode(['state' => $new_state], JSON_UNESCAPED_UNICODE);
+} catch (Throwable $e) {
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+    http_response_code(500);
+    echo json_encode(['error' => 'server error']);
+}

--- a/api/new_game.php
+++ b/api/new_game.php
@@ -1,0 +1,47 @@
+<?php
+// Create a new game with frozen rules snapshot.
+
+declare(strict_types=1);
+
+header('Content-Type: application/json');
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!is_array($input)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'invalid json']);
+    exit;
+}
+
+$host_user_id = isset($input['host_user_id']) ? (int)$input['host_user_id'] : 0;
+$ruleset_id = $input['ruleset_id'] ?? '';
+$rules_snapshot = $input['rules_json_snapshot'] ?? null;
+$initial_state = $input['state'] ?? [];
+
+if ($host_user_id <= 0 || !$ruleset_id || !is_array($rules_snapshot)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'missing fields']);
+    exit;
+}
+
+$initial_state['version'] = $initial_state['version'] ?? 0;
+
+function db(): PDO {
+    $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
+    $pdo = new PDO($dsn);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    return $pdo;
+}
+
+$pdo = db();
+$pdo->beginTransaction();
+$stmt = $pdo->prepare('INSERT INTO games (host_user_id, state_json, version, ruleset_id, rules_json_snapshot) VALUES (:host, :state, 0, :ruleset, :rules) RETURNING id');
+$stmt->execute([
+    ':host' => $host_user_id,
+    ':state' => json_encode($initial_state, JSON_UNESCAPED_UNICODE),
+    ':ruleset' => $ruleset_id,
+    ':rules' => json_encode($rules_snapshot, JSON_UNESCAPED_UNICODE),
+]);
+$game_id = (int)$stmt->fetchColumn();
+$pdo->commit();
+
+echo json_encode(['game_id' => $game_id, 'state' => $initial_state], JSON_UNESCAPED_UNICODE);

--- a/api/state.php
+++ b/api/state.php
@@ -1,0 +1,44 @@
+<?php
+// Stateless endpoint returning game state and version.
+
+declare(strict_types=1);
+
+header('Content-Type: application/json');
+
+$game_id = isset($_GET['game_id']) ? (int)$_GET['game_id'] : 0;
+if ($game_id <= 0) {
+    http_response_code(400);
+    echo json_encode(['error' => 'missing game_id']);
+    exit;
+}
+
+function db(): PDO {
+    $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
+    $pdo = new PDO($dsn);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    return $pdo;
+}
+
+$pdo = db();
+$pdo->beginTransaction();
+$stmt = $pdo->prepare('SELECT state_json, version, rules_json_snapshot FROM games WHERE id = ?');
+$stmt->execute([$game_id]);
+$row = $stmt->fetch(PDO::FETCH_ASSOC);
+$pdo->commit();
+
+if (!$row) {
+    http_response_code(404);
+    echo json_encode(['error' => 'game not found']);
+    exit;
+}
+
+$state = json_decode($row['state_json'], true);
+$state['version'] = (int)$row['version'];
+
+$response = [
+    'state' => $state,
+    'rules' => json_decode($row['rules_json_snapshot'], true),
+    'version' => (int)$row['version'],
+];
+
+echo json_encode($response, JSON_UNESCAPED_UNICODE);

--- a/api/stream.php
+++ b/api/stream.php
@@ -1,0 +1,41 @@
+<?php
+// Simple Server-Sent Events endpoint for game state updates.
+
+declare(strict_types=1);
+
+header('Content-Type: text/event-stream');
+header('Cache-Control: no-cache');
+
+$game_id = isset($_GET['game_id']) ? (int)$_GET['game_id'] : 0;
+$last_id = isset($_SERVER['HTTP_LAST_EVENT_ID']) ? (int)$_SERVER['HTTP_LAST_EVENT_ID'] : 0;
+if ($game_id <= 0) {
+    http_response_code(400);
+    echo "data: {\"error\":\"missing game_id\"}\n\n";
+    exit;
+}
+
+function db(): PDO {
+    $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
+    $pdo = new PDO($dsn);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    return $pdo;
+}
+
+$pdo = db();
+while (true) {
+    $pdo->beginTransaction();
+    $stmt = $pdo->prepare('SELECT state_json, version FROM games WHERE id = ?');
+    $stmt->execute([$game_id]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    $pdo->commit();
+    if ($row && (int)$row['version'] > $last_id) {
+        $state = $row['state_json'];
+        $id = (int)$row['version'];
+        echo "id: {$id}\n";
+        echo "data: {$state}\n\n";
+        @ob_flush();
+        @flush();
+        $last_id = $id;
+    }
+    sleep(1);
+}


### PR DESCRIPTION
## Summary
- add `state.php` to read game state snapshots
- add `new_game.php` to create games with frozen rulesets
- add `act.php` for transactional actions with version increment
- add `stream.php` for SSE state updates

## Testing
- `php -l api/state.php`
- `php -l api/new_game.php`
- `php -l api/act.php`
- `php -l api/stream.php`


------
https://chatgpt.com/codex/tasks/task_e_689cbfdeb90c8320b4f0208c5d23df85