### PR TITLE
Add password hash column to users

### DIFF
--- a/migrations/002_add_password_hash.sql
+++ b/migrations/002_add_password_hash.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN password_hash TEXT NOT NULL;


### PR DESCRIPTION
## Summary
- add migration to store password hashes on users

## Testing
- `sudo -u postgres psql -d dark_promoters -f migrations/001_initial.sql`
- `sudo -u postgres psql -d dark_promoters -f migrations/002_add_password_hash.sql`
- `sudo -u postgres psql -d dark_promoters -c "INSERT INTO users (username, password_hash) VALUES ('alice', md5('password'));"`
- `sudo -u postgres psql -d dark_promoters -c "SELECT id, username, password_hash FROM users;"`


------
https://chatgpt.com/codex/tasks/task_e_689cc27744688320abe4ef80801a3d3f