### PR TITLE
Add session authentication helper

### DIFF
--- a/api/_auth.php
+++ b/api/_auth.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Require a valid session based on Authorization header or session_token parameter.
+ *
+ * @param PDO $db Database connection
+ * @return array Authenticated user as ['id' => int, 'username' => string]
+ */
+function require_session(PDO $db): array {
+    $token = '';
+
+    // Check Authorization: Bearer <token> header
+    $authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+    if (stripos($authHeader, 'Bearer ') === 0) {
+        $token = substr($authHeader, 7);
+    }
+
+    // Fallback to session_token parameter (GET/POST)
+    if ($token === '') {
+        $param = $_REQUEST['session_token'] ?? '';
+        if (is_string($param)) {
+            $token = $param;
+        }
+    }
+
+    if ($token === '') {
+        http_response_code(401);
+        echo json_encode(['error' => 'missing session token'], JSON_UNESCAPED_UNICODE);
+        exit;
+    }
+
+    $stmt = $db->prepare('SELECT u.id, u.username FROM sessions s JOIN users u ON s.user_id = u.id WHERE s.session_token = ? AND s.expires_at > NOW()');
+    $stmt->execute([$token]);
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$user) {
+        http_response_code(401);
+        echo json_encode(['error' => 'invalid session'], JSON_UNESCAPED_UNICODE);
+        exit;
+    }
+
+    return [
+        'id' => (int)$user['id'],
+        'username' => $user['username'],
+    ];
+}
+


### PR DESCRIPTION
## Summary
- Add `api/_auth.php` with `require_session(PDO $db)` to validate `Authorization: Bearer` headers or `session_token` params
- Return user details when valid or send HTTP 401 responses otherwise

## Testing
- `php -l api/_auth.php`


------
https://chatgpt.com/codex/tasks/task_e_689cd13432748320b21cdc145eb7528f