### PR TITLE
Add basic auth pages with login, register and logout flow

### DIFF
--- a/public/auth.js
+++ b/public/auth.js
@@ -1,0 +1,74 @@
+async function sendAuth(url, data) {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(data)
+  });
+  return res.json();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const loginForm = document.getElementById('login_form');
+  if (loginForm) {
+    loginForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const formData = new FormData(loginForm);
+      const payload = Object.fromEntries(formData.entries());
+      try {
+        const json = await sendAuth('/api/login.php', payload);
+        if (json.session_token) {
+          localStorage.setItem('session_token', json.session_token);
+          window.location.href = 'index.html';
+        } else {
+          alert(json.error || 'Login failed');
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    });
+  }
+
+  const registerForm = document.getElementById('register_form');
+  if (registerForm) {
+    registerForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const formData = new FormData(registerForm);
+      const payload = Object.fromEntries(formData.entries());
+      try {
+        const json = await sendAuth('/api/register.php', payload);
+        if (json.session_token) {
+          localStorage.setItem('session_token', json.session_token);
+          window.location.href = 'index.html';
+        } else {
+          alert(json.error || 'Registration failed');
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    });
+  }
+
+  const logoutBtn = document.getElementById('logout_btn');
+  if (logoutBtn) {
+    logoutBtn.addEventListener('click', async () => {
+      const token = localStorage.getItem('session_token');
+      try {
+        await fetch('/api/logout.php', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': token ? `Bearer ${token}` : ''
+          },
+          body: JSON.stringify({ session_token: token })
+        });
+      } catch (err) {
+        console.error(err);
+      } finally {
+        localStorage.removeItem('session_token');
+        window.location.href = 'login.html';
+      }
+    });
+  }
+});

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Lobby</title>
+</head>
+<body>
+  <h1>Lobby</h1>
+  <button id="logout_btn">Logout</button>
+  <script src="auth.js"></script>
+</body>
+</html>

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Login</title>
+</head>
+<body>
+  <h1>Login</h1>
+  <form id="login_form">
+    <label>Username:
+      <input type="text" name="username" required>
+    </label>
+    <br>
+    <label>Password:
+      <input type="password" name="password" required>
+    </label>
+    <br>
+    <button type="submit">Login</button>
+  </form>
+  <p>No account? <a href="register.html">Register</a></p>
+  <script src="auth.js"></script>
+</body>
+</html>

--- a/public/register.html
+++ b/public/register.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Register</title>
+</head>
+<body>
+  <h1>Register</h1>
+  <form id="register_form">
+    <label>Username:
+      <input type="text" name="username" required>
+    </label>
+    <br>
+    <label>Password:
+      <input type="password" name="password" required>
+    </label>
+    <br>
+    <button type="submit">Register</button>
+  </form>
+  <p>Already have an account? <a href="login.html">Login</a></p>
+  <script src="auth.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add simple login and register HTML pages with forms
- Implement shared auth.js to send credentials, store `session_token`, and support logout
- Provide lobby index with logout button

## Testing
- `node --check public/auth.js`
- `php -l api/login.php`
- `php -l api/register.php`
- `php -l api/logout.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cd281c6188320b08f7f4a333b7a01