### PR TITLE
Add card inventory schema and API with frontend view

### DIFF
--- a/api/inventory.php
+++ b/api/inventory.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/_auth.php';
+
+header('Content-Type: application/json');
+
+function db(): PDO {
+    $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
+    $pdo = new PDO($dsn);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    return $pdo;
+}
+
+$pdo = db();
+$user = require_session($pdo);
+
+if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+    $stmt = $pdo->prepare('SELECT card_id, qty FROM card_inventory WHERE user_id = ? ORDER BY card_id');
+    $stmt->execute([$user['id']]);
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    $inventory = array_map(function ($r) {
+        return [
+            'card_id' => $r['card_id'],
+            'qty' => (int)$r['qty'],
+        ];
+    }, $rows);
+    echo json_encode(['inventory' => $inventory], JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $input = json_decode(file_get_contents('php://input'), true);
+    if (!is_array($input)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'invalid json']);
+        exit;
+    }
+    $card_id = trim((string)($input['card_id'] ?? ''));
+    $qty = isset($input['qty']) ? (int)$input['qty'] : 0;
+    if ($card_id === '') {
+        http_response_code(400);
+        echo json_encode(['error' => 'missing card_id']);
+        exit;
+    }
+    if ($qty > 0) {
+        $stmt = $pdo->prepare('INSERT INTO card_inventory (user_id, card_id, qty) VALUES (:uid, :cid, :qty) ON CONFLICT (user_id, card_id) DO UPDATE SET qty = EXCLUDED.qty');
+        $stmt->execute([
+            ':uid' => $user['id'],
+            ':cid' => $card_id,
+            ':qty' => $qty,
+        ]);
+    } else {
+        $stmt = $pdo->prepare('DELETE FROM card_inventory WHERE user_id = :uid AND card_id = :cid');
+        $stmt->execute([
+            ':uid' => $user['id'],
+            ':cid' => $card_id,
+        ]);
+        $qty = 0;
+    }
+    echo json_encode(['card_id' => $card_id, 'qty' => $qty], JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+http_response_code(405);
+echo json_encode(['error' => 'method not allowed']);

--- a/migrations/003_card_inventory.sql
+++ b/migrations/003_card_inventory.sql
@@ -1,0 +1,6 @@
+CREATE TABLE card_inventory (
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  card_id TEXT NOT NULL,
+  qty INTEGER NOT NULL,
+  PRIMARY KEY (user_id, card_id)
+);

--- a/public/inventory.html
+++ b/public/inventory.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Inventory</title>
+</head>
+<body>
+  <h1>Inventory</h1>
+  <button id="logout_btn">Logout</button>
+  <input type="text" id="filter" placeholder="Filter cards">
+  <table>
+    <thead>
+      <tr><th>Card ID</th><th>Quantity</th></tr>
+    </thead>
+    <tbody id="inventory_body"></tbody>
+  </table>
+  <script src="auth.js"></script>
+  <script src="inventory.js"></script>
+</body>
+</html>

--- a/public/inventory.js
+++ b/public/inventory.js
@@ -1,0 +1,46 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const token = localStorage.getItem('session_token');
+  if (!token) {
+    window.location.href = 'login.html';
+    return;
+  }
+
+  const filterInput = document.getElementById('filter');
+  const tbody = document.getElementById('inventory_body');
+  let inventory = [];
+
+  async function loadInventory() {
+    try {
+      const res = await fetch('/api/inventory.php', {
+        headers: {
+          'Authorization': `Bearer ${token}`
+        }
+      });
+      const json = await res.json();
+      inventory = json.inventory || [];
+      render();
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  function render() {
+    const term = filterInput.value.toLowerCase();
+    tbody.innerHTML = '';
+    inventory
+      .filter(item => item.card_id.toLowerCase().includes(term))
+      .forEach(item => {
+        const tr = document.createElement('tr');
+        const tdId = document.createElement('td');
+        tdId.textContent = item.card_id;
+        const tdQty = document.createElement('td');
+        tdQty.textContent = item.qty;
+        tr.appendChild(tdId);
+        tr.appendChild(tdQty);
+        tbody.appendChild(tr);
+      });
+  }
+
+  filterInput.addEventListener('input', render);
+  loadInventory();
+});


### PR DESCRIPTION
## Summary
- add `card_inventory` table for tracking per-user card quantities
- implement authenticated inventory API with list and update operations
- add inventory page with filterable card list

## Testing
- `php -l api/inventory.php`
- `node --check public/inventory.js`


------
https://chatgpt.com/codex/tasks/task_e_689cd5910ea88320b3ba417170dda8a7