### PR TITLE
feat: add card renderer with i18n and lazy art

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,87 @@
+(async function() {
+  const state = { locale: 'en', cards: [] };
+  const container = document.getElementById('card-container');
+  const langSwitch = document.getElementById('lang-switch');
+
+  const typeTranslations = {
+    act: { en: 'Act', de: 'Auftritt' },
+    sponsor: { en: 'Sponsor', de: 'Sponsor' },
+    location: { en: 'Location', de: 'Ort' },
+    marketing: { en: 'Marketing', de: 'Marketing' },
+    sabotage: { en: 'Sabotage', de: 'Sabotage' }
+  };
+
+  langSwitch.addEventListener('change', () => {
+    state.locale = langSwitch.value;
+    renderCards();
+  });
+
+  async function loadCards() {
+    try {
+      const res = await fetch('../api/cards.php');
+      const data = await res.json();
+      state.cards = data.cards || [];
+    } catch (e) {
+      console.error('Failed to load cards', e);
+    }
+  }
+
+  function renderCard(card) {
+    const cardEl = document.createElement('div');
+    cardEl.className = 'card';
+    if (card.style && card.style.color) {
+      cardEl.style.borderColor = card.style.color;
+    }
+
+    const art = document.createElement('img');
+    art.className = 'art';
+    art.alt = card.name[state.locale] || card.id;
+    art.dataset.src = card.art || 'https://via.placeholder.com/250x210?text=Art';
+    art.loading = 'lazy';
+    observer.observe(art);
+    cardEl.appendChild(art);
+
+    const title = document.createElement('div');
+    title.className = 'title';
+    title.textContent = card.name[state.locale] || card.name;
+    cardEl.appendChild(title);
+
+    const typeLine = document.createElement('div');
+    typeLine.className = 'type-line';
+    const typeTrans = typeTranslations[card.type];
+    typeLine.textContent = typeTrans ? typeTrans[state.locale] : card.type;
+    cardEl.appendChild(typeLine);
+
+    const rules = document.createElement('div');
+    rules.className = 'rules';
+    if (card.rules && typeof card.rules === 'object') {
+      rules.textContent = card.rules[state.locale] || '';
+    }
+    cardEl.appendChild(rules);
+
+    const frame = document.createElement('div');
+    frame.className = 'frame';
+    cardEl.appendChild(frame);
+    return cardEl;
+  }
+
+  function renderCards() {
+    container.innerHTML = '';
+    state.cards.forEach(card => {
+      container.appendChild(renderCard(card));
+    });
+  }
+
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        const img = entry.target;
+        img.src = img.dataset.src;
+        observer.unobserve(img);
+      }
+    });
+  }, { rootMargin: '50px' });
+
+  await loadCards();
+  renderCards();
+})();

--- a/public/cards.css
+++ b/public/cards.css
@@ -1,0 +1,69 @@
+body {
+  font-family: sans-serif;
+  background: #222;
+  color: #eee;
+  margin: 0;
+  padding: 0;
+}
+
+header {
+  padding: 1rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.card {
+  position: relative;
+  width: 250px;
+  height: 350px;
+  background: #000;
+  border-radius: 10px;
+  overflow: hidden;
+  color: #000;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.5);
+}
+
+.card .frame {
+  position: absolute;
+  inset: 0;
+  border: 8px solid #000;
+  border-radius: 10px;
+  pointer-events: none;
+}
+
+.card img.art {
+  width: 100%;
+  height: 60%;
+  object-fit: cover;
+  display: block;
+  background: #333;
+}
+
+.card .title {
+  font-weight: bold;
+  padding: 0.25rem 0.5rem;
+  background: rgba(255,255,255,0.8);
+}
+
+.card .type-line {
+  font-size: 0.85rem;
+  padding: 0.25rem 0.5rem;
+  background: rgba(255,255,255,0.8);
+}
+
+.card .rules {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 30%;
+  box-sizing: border-box;
+  padding: 0.5rem;
+  background: rgba(255,255,255,0.9);
+  font-size: 0.8rem;
+  overflow: auto;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -2,11 +2,18 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Lobby</title>
+  <title>Card Viewer</title>
+  <link rel="stylesheet" href="cards.css">
 </head>
 <body>
-  <h1>Lobby</h1>
-  <button id="logout_btn">Logout</button>
-  <script src="auth.js"></script>
+  <header>
+    <label for="lang-switch">Language:</label>
+    <select id="lang-switch">
+      <option value="en" selected>EN</option>
+      <option value="de">DE</option>
+    </select>
+  </header>
+  <main id="card-container" class="card-grid"></main>
+  <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- build card viewer index page and styling
- render cards with language toggle and lazy-loaded artwork

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cd8785d108320b2bacdd19dc588cc