### PR TITLE
Add sample cards, starter deck, and contributor docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NRW Noir — Dark Promoters (TCG prototype)
 
 A lightweight, extensible **virtual trading card game** about organizing gothic/alt-scene events in NRW.  
-Players compete for **Locations, Acts, Sponsors, Marketing** and **Audience**. All events happen **on the same day**.
+Players compete for **Locations, Acts, Sponsors, Marketing** and **Audience**. All events happen **on the same day**. Sample cards live in `/cards` and a demo starter deck is in `/starter_decks`.
 
 - **Stack:** PHP 8 + MySQL/MariaDB + HTML/CSS + vanilla JS (no frameworks)
 - **Cards as JSON files:** one file **per card** for drop-in extensibility
@@ -15,25 +15,18 @@ Players compete for **Locations, Acts, Sponsors, Marketing** and **Audience**. A
 4. Serve repo root via `php -S localhost:8080` (or your web server).
 5. Open `http://localhost:8080`.
 
+For detailed onboarding steps see `docs/ONBOARDING.md`.
+
 ## Repository Layout (proposed)
 
-/api/ # PHP endpoints (state, actions, cards loader, SSE)
-/cards/ # one JSON per card
-/core/
-/act/ # e.g. act_velvet_kain.json
-/sponsor/ # e.g. sponsor_noirwear.json
-/location/ # e.g. loc_matrix_bochum.json
-/marketing/
-/sabotage/
-/club/ # mode packs (Clubnight)
-/party/
-/festival1/ # 1-day festival
-/festival2/ # 2-day festival
-/frames/ # frame JSON + frame/overlay/texture assets
-/images/ # art, icons, textures
-/i18n/ # ui.en.json, ui.de.json (UI strings)
-/public/ # index.html, cards.css, app.js
-/docs/ # RULES.md (this repo), RULES.de.md (later), AGENTS.md
+/api/          # PHP endpoints (state, actions, cards loader, SSE)
+/cards/        # one JSON per card
+/starter_decks/# sample starter decks
+/i18n/        # ui.en.json, ui.de.json (UI strings)
+/public/       # index.html, cards.css, app.js
+/docs/         # RULES.md (EN), RULES.de.md (DE), ONBOARDING.md, CONTRIBUTING.md, AGENTS.md
+/migrations/   # SQL schema migrations
+/rulesets/     # versioned ruleset JSON
 
 
 ## Card Files (one JSON per card)
@@ -134,6 +127,7 @@ Building/Running
 Contributing
 
     See AGENTS.md for roles, tasks, and acceptance criteria.
+    See `docs/CONTRIBUTING.md` for guidelines.
 
     Lint JSON (UTF-8, no BOM). Keep schema = 1 for now.
 

--- a/RULES.md
+++ b/RULES.md
@@ -3,6 +3,8 @@
 > A competitive event-management card game set in the gothic/alt scene.  
 > All events happen on the **same day** — compete for Locations, Acts, Sponsors, Marketing, and Audience.
 
+Sample cards live in `/cards`, and a demo starter deck is in `/starter_decks`. A German translation is available in `docs/RULES.de.md`.
+
 ## 0) Objective & Setup
 - **Goal:** Highest **Profit** wins. Tie → most **Audience**, then lowest **Total Spend**.
 - **Start:** Each player gets **starting budget**, **audience base**, and **ticket price band options** per chosen **Mode** (see §8).

--- a/cards/act/demo.json
+++ b/cards/act/demo.json
@@ -6,6 +6,8 @@
     "en": "Demo Act",
     "de": "Demo-Auftritt"
   },
+  "cost": 5000,
+  "audience_pct": 0.1,
   "style": {
     "color": "#ff0000"
   }

--- a/cards/location/demo.json
+++ b/cards/location/demo.json
@@ -1,0 +1,14 @@
+{
+  "schema": 1,
+  "type": "location",
+  "id": "loc_demo",
+  "name": {
+    "en": "Demo Location",
+    "de": "Demo-Location"
+  },
+  "rent": 1000,
+  "capacity": 200,
+  "style": {
+    "color": "#00ff00"
+  }
+}

--- a/cards/marketing/demo.json
+++ b/cards/marketing/demo.json
@@ -1,0 +1,14 @@
+{
+  "schema": 1,
+  "type": "marketing",
+  "id": "marketing_demo",
+  "name": {
+    "en": "Demo Marketing",
+    "de": "Demo-Marketing"
+  },
+  "cost": 300,
+  "audience_pct": 0.05,
+  "style": {
+    "color": "#ffff00"
+  }
+}

--- a/cards/sabotage/demo.json
+++ b/cards/sabotage/demo.json
@@ -1,0 +1,16 @@
+{
+  "schema": 1,
+  "type": "sabotage",
+  "id": "sabotage_demo",
+  "name": {
+    "en": "Demo Sabotage",
+    "de": "Demo-Sabotage"
+  },
+  "text": {
+    "en": "-10 audience",
+    "de": "-10 Publikum"
+  },
+  "style": {
+    "color": "#ff00ff"
+  }
+}

--- a/cards/sponsor/demo.json
+++ b/cards/sponsor/demo.json
@@ -1,0 +1,14 @@
+{
+  "schema": 1,
+  "type": "sponsor",
+  "id": "sponsor_demo",
+  "name": {
+    "en": "Demo Sponsor",
+    "de": "Demo-Sponsor"
+  },
+  "min_slots": 1,
+  "payout_per_slot": 500,
+  "style": {
+    "color": "#0000ff"
+  }
+}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+Thanks for helping with **Dark Promoters**. Keep these guidelines in mind:
+
+- Read `AGENTS.md` for roles, tasks, and acceptance criteria.
+- Use 2-space indents, UTF-8, and LF line endings for JSON.
+- Card IDs follow `type_prefix_snake_case` (e.g. `act_demo`).
+- Provide English and German text for card fields like `name` and `text`.
+- Run `php api/cards.php` to ensure all card JSON loads without warnings.
+- Run available tests or linters before submitting a PR.
+
+For environment setup see `docs/ONBOARDING.md`.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,0 +1,19 @@
+# Onboarding
+
+Follow these steps to get a local instance of **Dark Promoters** running.
+
+## Prerequisites
+- PHP 8
+- MySQL or MariaDB
+
+## Setup
+1. Clone this repository.
+2. Apply migrations in `migrations/` (`001_initial.sql` then `002_add_password_hash.sql`).
+3. Create a `config.php` with your database credentials.
+4. Serve the repo root via `php -S localhost:8080`.
+5. Open `http://localhost:8080` in your browser.
+6. Validate cards via `php api/cards.php` (should list demo cards without warnings).
+
+## Next steps
+- Review `docs/CONTRIBUTING.md` and `AGENTS.md` before opening a pull request.
+- Use the sample cards under `cards/` and the demo deck under `starter_decks/` to explore the rules.

--- a/docs/RULES.de.md
+++ b/docs/RULES.de.md
@@ -3,6 +3,8 @@
 > Ein kompetitives Event-Management-Kartenspiel in der Gothic/Alt-Szene.  
 > Alle Events finden am **gleichen Tag** statt – ihr konkurriert um Locations, Acts, Sponsoren, Marketing und Publikum.
 
+Beispielkarten liegen unter `/cards`, ein Demo-Starterdeck unter `/starter_decks`. Die englische Version befindet sich in `../RULES.md`.
+
 ## 0) Ziel & Setup
 - **Ziel:** Höchster **Gewinn** gewinnt. Bei Gleichstand: höchste **Zuschauerzahl**, danach **geringste Gesamtausgaben**.
 - **Setup:** Pro **Modus** (siehe §8) gelten Startbudget, Zuschauer-Basis und Ticketpreis-Bänder.

--- a/starter_decks/demo.json
+++ b/starter_decks/demo.json
@@ -1,0 +1,15 @@
+{
+  "schema": 1,
+  "id": "deck_demo",
+  "name": {
+    "en": "Demo Deck",
+    "de": "Demo-Deck"
+  },
+  "cards": [
+    "act_demo",
+    "loc_demo",
+    "sponsor_demo",
+    "marketing_demo",
+    "sabotage_demo"
+  ]
+}


### PR DESCRIPTION
## Summary
- document sample cards and demo starter deck in README and rules
- add example cards for all types plus a demo starter deck
- include onboarding and contributing guides for new contributors

## Testing
- `find cards starter_decks -name '*.json' -print -exec jq empty {} +`
- `php api/cards.php`


------
https://chatgpt.com/codex/tasks/task_e_689cde63f8fc83209e2adda5f337c6b9