### PR TITLE
Add match creation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Backend: simple API
 
     Optional: GET /api/stream.php?game_id=… → SSE push updates
 
+    POST /api/new_match.php → create match and auto-join creator
+
 Economy: Points & Packs
 
     - Users start with 1000 points—enough for a starter pack and some booster packs on day one. A daily top-up script (`tools/points_topup.php`) adds 100 points to every account.

--- a/api/new_match.php
+++ b/api/new_match.php
@@ -1,0 +1,29 @@
+<?php
+// Create a new match and add the creator as first player
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/_auth.php';
+
+header('Content-Type: application/json');
+
+function db(): PDO {
+    $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
+    $pdo = new PDO($dsn);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    return $pdo;
+}
+
+$pdo = db();
+$user = require_session($pdo);
+
+$pdo->beginTransaction();
+$stmt = $pdo->prepare('INSERT INTO matches (creator_id, status) VALUES (:uid, :status) RETURNING id');
+$stmt->execute([':uid' => $user['id'], ':status' => 'waiting']);
+$matchId = (int)$stmt->fetchColumn();
+
+$stmt = $pdo->prepare('INSERT INTO match_players (match_id, user_id) VALUES (:mid, :uid)');
+$stmt->execute([':mid' => $matchId, ':uid' => $user['id']]);
+$pdo->commit();
+
+echo json_encode(['match_id' => $matchId], JSON_UNESCAPED_UNICODE);


### PR DESCRIPTION
## Summary
- Add `new_match.php` API to create a match and auto-join creator
- Document match creation endpoint in README

## Testing
- `php -l api/new_match.php`

------
https://chatgpt.com/codex/tasks/task_e_689d7f9c83208320b884e342b6500db6