### PR TITLE
Add match start endpoint and link games to matches

### DIFF
--- a/api/_game.php
+++ b/api/_game.php
@@ -1,0 +1,30 @@
+<?php
+// Shared game creation helper.
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/_ruleset.php';
+
+/**
+ * Create a new game row and return identifiers.
+ * Caller must handle transactions.
+ */
+function create_game(PDO $pdo, int $host_user_id, string $ruleset_id, array $initial_state, ?int $match_id = null): array {
+    $loaded = load_ruleset($ruleset_id);
+    $ruleset_id = $loaded['id'];
+    $rules_snapshot = $loaded['data'];
+
+    $initial_state['version'] = $initial_state['version'] ?? 0;
+
+    $stmt = $pdo->prepare('INSERT INTO games (host_user_id, state_json, version, ruleset_id, rules_json_snapshot, match_id) VALUES (:host, :state, 0, :ruleset, :rules, :match) RETURNING id');
+    $stmt->execute([
+        ':host' => $host_user_id,
+        ':state' => json_encode($initial_state, JSON_UNESCAPED_UNICODE),
+        ':ruleset' => $ruleset_id,
+        ':rules' => json_encode($rules_snapshot, JSON_UNESCAPED_UNICODE),
+        ':match' => $match_id,
+    ]);
+    $game_id = (int)$stmt->fetchColumn();
+
+    return ['game_id' => $game_id, 'state' => $initial_state];
+}

--- a/api/matches_start.php
+++ b/api/matches_start.php
@@ -1,0 +1,95 @@
+<?php
+// Start a match and create a linked game.
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/_auth.php';
+require_once __DIR__ . '/_game.php';
+
+header('Content-Type: application/json');
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!is_array($input)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'invalid json'], JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+$match_id = isset($input['match_id']) ? (int)$input['match_id'] : 0;
+$ruleset_id = $input['ruleset_id'] ?? 'default.latest';
+if ($match_id <= 0) {
+    http_response_code(400);
+    echo json_encode(['error' => 'missing match_id'], JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+function db(): PDO {
+    $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
+    $pdo = new PDO($dsn);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    return $pdo;
+}
+
+$pdo = db();
+$user = require_session($pdo);
+
+try {
+    $pdo->beginTransaction();
+    $stmt = $pdo->prepare('SELECT creator_id, status FROM matches WHERE id = :id FOR UPDATE');
+    $stmt->execute([':id' => $match_id]);
+    $match = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$match) {
+        $pdo->rollBack();
+        http_response_code(404);
+        echo json_encode(['error' => 'match not found'], JSON_UNESCAPED_UNICODE);
+        exit;
+    }
+    if ((int)$match['creator_id'] !== $user['id']) {
+        $pdo->rollBack();
+        http_response_code(403);
+        echo json_encode(['error' => 'not creator'], JSON_UNESCAPED_UNICODE);
+        exit;
+    }
+    if ($match['status'] !== 'waiting') {
+        $pdo->rollBack();
+        http_response_code(400);
+        echo json_encode(['error' => 'match not startable'], JSON_UNESCAPED_UNICODE);
+        exit;
+    }
+    $stmt = $pdo->prepare('SELECT user_id FROM match_players WHERE match_id = :mid');
+    $stmt->execute([':mid' => $match_id]);
+    $players = $stmt->fetchAll(PDO::FETCH_COLUMN, 0);
+    if (count($players) < 2) {
+        $pdo->rollBack();
+        http_response_code(400);
+        echo json_encode(['error' => 'not enough players'], JSON_UNESCAPED_UNICODE);
+        exit;
+    }
+
+    $initial_state = [];
+    $result = create_game($pdo, $user['id'], $ruleset_id, $initial_state, $match_id);
+    $game_id = $result['game_id'];
+
+    $insert = $pdo->prepare('INSERT INTO game_players (game_id, user_id) VALUES (:gid, :uid)');
+    foreach ($players as $pid) {
+        $insert->execute([':gid' => $game_id, ':uid' => $pid]);
+    }
+
+    $stmt = $pdo->prepare('UPDATE matches SET status = :status WHERE id = :id');
+    $stmt->execute([':status' => 'started', ':id' => $match_id]);
+
+    $pdo->commit();
+    echo json_encode(['game_id' => $game_id], JSON_UNESCAPED_UNICODE);
+} catch (RuntimeException $e) {
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+    http_response_code(400);
+    echo json_encode(['error' => 'invalid ruleset'], JSON_UNESCAPED_UNICODE);
+} catch (Throwable $e) {
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+    http_response_code(500);
+    echo json_encode(['error' => 'server error'], JSON_UNESCAPED_UNICODE);
+}

--- a/api/new_game.php
+++ b/api/new_game.php
@@ -3,7 +3,7 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/_ruleset.php';
+require_once __DIR__ . '/_game.php';
 
 header('Content-Type: application/json');
 
@@ -17,25 +17,13 @@ if (!is_array($input)) {
 $host_user_id = isset($input['host_user_id']) ? (int)$input['host_user_id'] : 0;
 $ruleset_id = $input['ruleset_id'] ?? 'default.latest';
 $initial_state = $input['state'] ?? [];
+$match_id = isset($input['match_id']) ? (int)$input['match_id'] : null;
 
 if ($host_user_id <= 0 || !is_array($initial_state)) {
     http_response_code(400);
     echo json_encode(['error' => 'missing fields']);
     exit;
 }
-
-try {
-    $loaded = load_ruleset($ruleset_id);
-} catch (RuntimeException $e) {
-    http_response_code(400);
-    echo json_encode(['error' => 'invalid ruleset']);
-    exit;
-}
-
-$ruleset_id = $loaded['id'];
-$rules_snapshot = $loaded['data'];
-
-$initial_state['version'] = $initial_state['version'] ?? 0;
 
 function db(): PDO {
     $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
@@ -44,16 +32,22 @@ function db(): PDO {
     return $pdo;
 }
 
-$pdo = db();
-$pdo->beginTransaction();
-$stmt = $pdo->prepare('INSERT INTO games (host_user_id, state_json, version, ruleset_id, rules_json_snapshot) VALUES (:host, :state, 0, :ruleset, :rules) RETURNING id');
-$stmt->execute([
-    ':host' => $host_user_id,
-    ':state' => json_encode($initial_state, JSON_UNESCAPED_UNICODE),
-    ':ruleset' => $ruleset_id,
-    ':rules' => json_encode($rules_snapshot, JSON_UNESCAPED_UNICODE),
-]);
-$game_id = (int)$stmt->fetchColumn();
-$pdo->commit();
-
-echo json_encode(['game_id' => $game_id, 'state' => $initial_state], JSON_UNESCAPED_UNICODE);
+try {
+    $pdo = db();
+    $pdo->beginTransaction();
+    $result = create_game($pdo, $host_user_id, $ruleset_id, $initial_state, $match_id);
+    $pdo->commit();
+    echo json_encode($result, JSON_UNESCAPED_UNICODE);
+} catch (RuntimeException $e) {
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+    http_response_code(400);
+    echo json_encode(['error' => 'invalid ruleset'], JSON_UNESCAPED_UNICODE);
+} catch (Throwable $e) {
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+    http_response_code(500);
+    echo json_encode(['error' => 'server error'], JSON_UNESCAPED_UNICODE);
+}

--- a/migrations/007_add_match_id_to_games.sql
+++ b/migrations/007_add_match_id_to_games.sql
@@ -1,0 +1,2 @@
+-- Link games to matches
+ALTER TABLE games ADD COLUMN match_id INTEGER REFERENCES matches(id);


### PR DESCRIPTION
## Summary
- add shared `create_game` helper with optional `match_id`
- extend `new_game.php` to use helper and support linked matches
- create `matches_start.php` to allow creators to start matches with minimum player check
- add migration to link games to matches

## Testing
- `php -l api/_game.php`
- `php -l api/new_game.php`
- `php -l api/matches_start.php`


------
https://chatgpt.com/codex/tasks/task_e_689d81f5073c832098d39652f215a69b