### PR TITLE
Add match lobby with join and start functionality

### DIFF
--- a/api/matches_join.php
+++ b/api/matches_join.php
@@ -33,9 +33,9 @@ $user = require_session($pdo);
 
 try {
     $pdo->beginTransaction();
-    $stmt = $pdo->prepare('SELECT status FROM matches WHERE id = :id FOR UPDATE');
-    $stmt->execute([':id' => $match_id]);
-    $match = $stmt->fetch(PDO::FETCH_ASSOC);
+$stmt = $pdo->prepare('SELECT status, max_players FROM matches WHERE id = :id FOR UPDATE');
+$stmt->execute([':id' => $match_id]);
+$match = $stmt->fetch(PDO::FETCH_ASSOC);
     if (!$match) {
         $pdo->rollBack();
         http_response_code(404);
@@ -57,7 +57,7 @@ try {
         echo json_encode(['error' => 'already joined'], JSON_UNESCAPED_UNICODE);
         exit;
     }
-    if (count($players) >= 4) {
+    if (count($players) >= (int)$match['max_players']) {
         $pdo->rollBack();
         http_response_code(400);
         echo json_encode(['error' => 'match full'], JSON_UNESCAPED_UNICODE);

--- a/api/matches_list.php
+++ b/api/matches_list.php
@@ -3,6 +3,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/_auth.php';
+
 header('Content-Type: application/json');
 
 function db(): PDO {
@@ -13,9 +15,10 @@ function db(): PDO {
 }
 
 $pdo = db();
+$user = require_session($pdo);
 
 $stmt = $pdo->query(
-    "SELECT m.id AS match_id, mp.user_id, u.username
+    "SELECT m.id AS match_id, m.name, m.max_players, m.creator_id, mp.user_id, u.username
      FROM matches m
      LEFT JOIN match_players mp ON mp.match_id = m.id
      LEFT JOIN users u ON mp.user_id = u.id
@@ -29,6 +32,9 @@ while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
     if (!isset($matches[$id])) {
         $matches[$id] = [
             'id' => $id,
+            'name' => $row['name'],
+            'max_players' => (int)$row['max_players'],
+            'creator_id' => (int)$row['creator_id'],
             'players' => [],
         ];
     }
@@ -40,4 +46,4 @@ while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
     }
 }
 
-echo json_encode(array_values($matches), JSON_UNESCAPED_UNICODE);
+echo json_encode(['user_id' => $user['id'], 'matches' => array_values($matches)], JSON_UNESCAPED_UNICODE);

--- a/api/new_match.php
+++ b/api/new_match.php
@@ -14,12 +14,32 @@ function db(): PDO {
     return $pdo;
 }
 
+$input = json_decode(file_get_contents('php://input'), true);
+if (!is_array($input)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'invalid json'], JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+$name = trim((string)($input['name'] ?? ''));
+$max = isset($input['max_players']) ? (int)$input['max_players'] : 0;
+if ($name === '' || $max < 2 || $max > 4) {
+    http_response_code(400);
+    echo json_encode(['error' => 'invalid params'], JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
 $pdo = db();
 $user = require_session($pdo);
 
 $pdo->beginTransaction();
-$stmt = $pdo->prepare('INSERT INTO matches (creator_id, status) VALUES (:uid, :status) RETURNING id');
-$stmt->execute([':uid' => $user['id'], ':status' => 'waiting']);
+$stmt = $pdo->prepare('INSERT INTO matches (creator_id, status, name, max_players) VALUES (:uid, :status, :name, :max) RETURNING id');
+$stmt->execute([
+    ':uid' => $user['id'],
+    ':status' => 'waiting',
+    ':name' => $name,
+    ':max' => $max,
+]);
 $matchId = (int)$stmt->fetchColumn();
 
 $stmt = $pdo->prepare('INSERT INTO match_players (match_id, user_id) VALUES (:mid, :uid)');

--- a/i18n/ui.de.json
+++ b/i18n/ui.de.json
@@ -29,5 +29,14 @@
   "cost_header": "Kosten",
   "buy_header": "Kaufen",
   "buy_button": "Kaufen",
-  "purchase_failed": "Kauf fehlgeschlagen"
+  "purchase_failed": "Kauf fehlgeschlagen",
+  "matches_title": "Matches",
+  "match_name_label": "Name:",
+  "max_players_label": "Max. Spieler:",
+  "create_match_button": "Match erstellen",
+  "match_name_header": "Match",
+  "players_header": "Spieler",
+  "actions_header": "Aktionen",
+  "join_button": "Beitreten",
+  "start_button": "Starten"
 }

--- a/i18n/ui.en.json
+++ b/i18n/ui.en.json
@@ -29,5 +29,14 @@
   "cost_header": "Cost",
   "buy_header": "Buy",
   "buy_button": "Buy",
-  "purchase_failed": "Purchase failed"
+  "purchase_failed": "Purchase failed",
+  "matches_title": "Matches",
+  "match_name_label": "Name:",
+  "max_players_label": "Max players:",
+  "create_match_button": "Create Match",
+  "match_name_header": "Match",
+  "players_header": "Players",
+  "actions_header": "Actions",
+  "join_button": "Join",
+  "start_button": "Start"
 }

--- a/migrations/008_match_details.sql
+++ b/migrations/008_match_details.sql
@@ -1,0 +1,3 @@
+-- Add name and max_players columns to matches
+ALTER TABLE matches ADD COLUMN name TEXT NOT NULL DEFAULT '';
+ALTER TABLE matches ADD COLUMN max_players INTEGER NOT NULL DEFAULT 4;

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,7 @@
       <option value="de">DE</option>
     </select>
     <span data-i18n="points_label">Points:</span> <span id="points">0</span>
+    <a href="matches.html" data-i18n="matches_title">Matches</a>
   </header>
   <main id="card-container" class="card-grid"></main>
   <script src="i18n.js"></script>

--- a/public/matches.html
+++ b/public/matches.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title data-i18n="matches_title">Matches</title>
+</head>
+<body>
+  <header>
+    <label for="lang-switch" data-i18n="language_label">Language:</label>
+    <select id="lang-switch">
+      <option value="en">EN</option>
+      <option value="de">DE</option>
+    </select>
+    <button id="logout_btn" data-i18n="logout_button">Logout</button>
+  </header>
+  <h1 data-i18n="matches_title">Matches</h1>
+  <form id="create_match_form">
+    <label for="match_name" data-i18n="match_name_label">Name:</label>
+    <input type="text" id="match_name" name="name" required>
+    <label for="max_players" data-i18n="max_players_label">Max players:</label>
+    <input type="number" id="max_players" name="max_players" min="2" max="4" value="4" required>
+    <button type="submit" data-i18n="create_match_button">Create Match</button>
+  </form>
+  <table>
+    <thead>
+      <tr>
+        <th data-i18n="match_name_header">Match</th>
+        <th data-i18n="players_header">Players</th>
+        <th data-i18n="actions_header">Actions</th>
+      </tr>
+    </thead>
+    <tbody id="matches_body"></tbody>
+  </table>
+  <script src="i18n.js"></script>
+  <script src="auth.js"></script>
+  <script src="matches.js"></script>
+</body>
+</html>

--- a/public/matches.js
+++ b/public/matches.js
@@ -1,0 +1,107 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const token = localStorage.getItem('session_token');
+  if (!token) {
+    window.location.href = 'login.html';
+    return;
+  }
+
+  const tbody = document.getElementById('matches_body');
+  const form = document.getElementById('create_match_form');
+  const nameInput = document.getElementById('match_name');
+  const maxInput = document.getElementById('max_players');
+  let currentUser = null;
+
+  async function loadMatches() {
+    try {
+      const res = await fetch('/api/matches_list.php', {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      const json = await res.json();
+      currentUser = json.user_id;
+      render(json.matches || []);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  function render(matches) {
+    tbody.innerHTML = '';
+    matches.forEach(match => {
+      const tr = document.createElement('tr');
+      const tdName = document.createElement('td');
+      tdName.textContent = match.name;
+      const tdPlayers = document.createElement('td');
+      const playersText = match.players.map(p => p.username).join(', ');
+      tdPlayers.textContent = `${match.players.length}/${match.max_players} ${playersText}`.trim();
+      const tdActions = document.createElement('td');
+      const joined = match.players.some(p => p.id === currentUser);
+      if (!joined && match.players.length < match.max_players) {
+        const joinBtn = document.createElement('button');
+        joinBtn.textContent = window.i18n ? window.i18n.t('join_button') : 'Join';
+        joinBtn.addEventListener('click', async () => {
+          try {
+            await fetch('/api/matches_join.php', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${token}`
+              },
+              body: JSON.stringify({ match_id: match.id })
+            });
+            loadMatches();
+          } catch (err) {
+            console.error(err);
+          }
+        });
+        tdActions.appendChild(joinBtn);
+      }
+      if (match.creator_id === currentUser) {
+        const startBtn = document.createElement('button');
+        startBtn.textContent = window.i18n ? window.i18n.t('start_button') : 'Start';
+        startBtn.addEventListener('click', async () => {
+          try {
+            await fetch('/api/matches_start.php', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${token}`
+              },
+              body: JSON.stringify({ match_id: match.id })
+            });
+            loadMatches();
+          } catch (err) {
+            console.error(err);
+          }
+        });
+        tdActions.appendChild(startBtn);
+      }
+      tr.appendChild(tdName);
+      tr.appendChild(tdPlayers);
+      tr.appendChild(tdActions);
+      tbody.appendChild(tr);
+    });
+  }
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const name = nameInput.value.trim();
+    const maxPlayers = parseInt(maxInput.value, 10);
+    try {
+      await fetch('/api/new_match.php', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({ name, max_players: maxPlayers })
+      });
+      nameInput.value = '';
+      loadMatches();
+    } catch (err) {
+      console.error(err);
+    }
+  });
+
+  loadMatches();
+  setInterval(loadMatches, 5000);
+});


### PR DESCRIPTION
## Summary
- allow matches to have a name and max player count
- support creating, listing, joining and starting matches from a simple lobby UI
- add translations for new lobby interface

## Testing
- `php -l api/new_match.php api/matches_list.php api/matches_join.php`
- `node --check public/matches.js`
- `python -m json.tool i18n/ui.en.json`
- `python -m json.tool i18n/ui.de.json`


------
https://chatgpt.com/codex/tasks/task_e_689d832bcd648320a74d01fdd70d9975