### PR TITLE
feat: stream game updates via version

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -148,10 +148,12 @@
       const es = new EventSource(`/api/stream.php?game_id=${gameId}`);
       es.onmessage = e => {
         try {
-          const state = JSON.parse(e.data);
-          expectedVersion = parseInt(e.lastEventId, 10) || expectedVersion;
-          state.version = expectedVersion;
-          renderState(state);
+          const msg = JSON.parse(e.data);
+          const version = parseInt(msg.version, 10);
+          if (version && version > expectedVersion) {
+            expectedVersion = version;
+            loadState();
+          }
         } catch (err) {
           console.error('Bad SSE data', err);
         }


### PR DESCRIPTION
## Summary
- emit version-only Server-Sent Events when a game's version changes
- auto-refresh game state via EventSource with polling fallback when SSE unsupported

## Testing
- `php -l api/stream.php`
- `node --check public/game.js`


------
https://chatgpt.com/codex/tasks/task_e_689d91dcf5ec83208f103ed139574bf3