### PR TITLE
feat: interactive setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,9 @@ Players compete for **Locations, Acts, Sponsors, Marketing** and **Audience**. A
 
 ## Quick Start (dev)
 1. PHP 8 + MySQL/MariaDB installed.
-2. Create DB tables: run migrations in `/migrations` (`001_initial.sql` then `002_add_password_hash.sql`).
-3. Configure `config.php` (DB creds).
-4. Serve repo root via `php -S localhost:8080` (or your web server).
-5. Open `http://localhost:8080`.
+2. Run `php setup.php` and follow the prompts to create the database, apply migrations and write `config.php`.
+3. Serve repo root via `php -S localhost:8080` (or your web server).
+4. Open `http://localhost:8080`.
 
 For detailed onboarding steps see `docs/ONBOARDING.md`.
 

--- a/setup.php
+++ b/setup.php
@@ -1,0 +1,55 @@
+<?php
+// Interactive setup script to configure database and run migrations
+
+function prompt(string $prompt, string $default = ''): string {
+    if ($default !== '') {
+        $prompt .= " [{$default}]";
+    }
+    $prompt .= ': ';
+    $input = readline($prompt);
+    if ($input === false || $input === '') {
+        return $default;
+    }
+    return $input;
+}
+
+// Collect DB credentials
+$host = prompt('DB host', 'localhost');
+$port = prompt('DB port', '3306');
+$name = prompt('DB name', 'dark_promoters');
+$user = prompt('DB user', 'root');
+$pass = prompt('DB password');
+
+// Write config.php
+$configContent = "<?php\nreturn [\n    'db_host' => '" . addslashes($host) . "',\n    'db_port' => '" . addslashes($port) . "',\n    'db_name' => '" . addslashes($name) . "',\n    'db_user' => '" . addslashes($user) . "',\n    'db_pass' => '" . addslashes($pass) . "',\n];\n";
+file_put_contents(__DIR__ . '/config.php', $configContent);
+echo "config.php written\n";
+
+// Connect to MySQL
+$dsn = "mysql:host={$host};port={$port}";
+try {
+    $pdo = new PDO($dsn, $user, $pass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+} catch (PDOException $e) {
+    fwrite(STDERR, "Connection failed: " . $e->getMessage() . "\n");
+    exit(1);
+}
+
+// Create database if not exists
+$pdo->exec("CREATE DATABASE IF NOT EXISTS `{$name}` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+$pdo->exec("USE `{$name}`");
+
+echo "Database '{$name}' ready\n";
+
+// Run migrations
+$migrationsDir = __DIR__ . '/migrations';
+$files = glob($migrationsDir . '/*.sql');
+natsort($files);
+foreach ($files as $file) {
+    $sql = file_get_contents($file);
+    echo "Applying " . basename($file) . "...";
+    $pdo->exec($sql);
+    echo "done\n";
+}
+
+echo "Setup complete.\n";
+


### PR DESCRIPTION
## Summary
- add `setup.php` to prompt for DB credentials, create database and run migrations
- document `php setup.php` in Quick Start instructions

## Testing
- `php -l setup.php`


------
https://chatgpt.com/codex/tasks/task_e_689cbddbb41c8320ae43348fb87cf6b7