### PR TITLE
Add web-based setup for database configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 A lightweight, extensible **virtual trading card game** about organizing gothic/alt-scene events in NRW.  
 Players compete for **Locations, Acts, Sponsors, Marketing** and **Audience**. All events happen **on the same day**. Sample cards live in `/cards` and a demo starter deck is in `/starter_decks`.
 
-- **Stack:** PHP 8 + MySQL/MariaDB + HTML/CSS + vanilla JS (no frameworks)
+- **Stack:** PHP 8 + PostgreSQL + HTML/CSS + vanilla JS (no frameworks)
 - **Cards as JSON files:** one file **per card** for drop-in extensibility
 - **Multilingual from the start:** **English + German** (UI + cards)
 - **Target:** fast prototyping, easy rules iteration, printable assets later
 
 ## Quick Start (dev)
-1. PHP 8 + MySQL/MariaDB installed.
-2. Run `php setup.php` and follow the prompts to create the database, apply migrations and write `config.php`.
+1. PHP 8 + PostgreSQL installed.
+2. Run `php setup.php` and follow the prompts to create the database, apply migrations and write `config.php`. Alternatively, start a web server and visit `public/setup.php` for a graphical setup.
 3. Serve repo root via `php -S localhost:8080` (or your web server).
 4. Open `http://localhost:8080`.
 

--- a/api/act.php
+++ b/api/act.php
@@ -4,6 +4,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/update_game.php';
+require_once __DIR__ . '/../db.php';
 
 header('Content-Type: application/json');
 
@@ -21,13 +22,6 @@ if ($game_id <= 0 || $expected_version < 0 || !is_array($action)) {
     http_response_code(400);
     echo json_encode(['error' => 'missing fields']);
     exit;
-}
-
-function db(): PDO {
-    $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
-    $pdo = new PDO($dsn);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    return $pdo;
 }
 
 function allowed_types_for_phase(string $phase): array {

--- a/api/decks.php
+++ b/api/decks.php
@@ -2,15 +2,9 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/_auth.php';
+require_once __DIR__ . '/../db.php';
 
 header('Content-Type: application/json');
-
-function db(): PDO {
-    $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
-    $pdo = new PDO($dsn);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    return $pdo;
-}
 
 $pdo = db();
 $user = require_session($pdo);

--- a/api/end_game.php
+++ b/api/end_game.php
@@ -4,6 +4,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/_points.php';
+require_once __DIR__ . '/../db.php';
 
 header('Content-Type: application/json');
 
@@ -21,13 +22,6 @@ if ($game_id <= 0 || $expected_version < 0 || $winner_id <= 0) {
     http_response_code(400);
     echo json_encode(['error' => 'missing fields']);
     exit;
-}
-
-function db(): PDO {
-    $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
-    $pdo = new PDO($dsn);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    return $pdo;
 }
 
 $pdo = db();

--- a/api/inventory.php
+++ b/api/inventory.php
@@ -2,15 +2,9 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/_auth.php';
+require_once __DIR__ . '/../db.php';
 
 header('Content-Type: application/json');
-
-function db(): PDO {
-    $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
-    $pdo = new PDO($dsn);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    return $pdo;
-}
 
 $pdo = db();
 $user = require_session($pdo);

--- a/api/login.php
+++ b/api/login.php
@@ -3,6 +3,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../db.php';
+
 header('Content-Type: application/json');
 
 $input = json_decode(file_get_contents('php://input'), true);
@@ -18,13 +20,6 @@ if ($username === '' || $password === '') {
     http_response_code(400);
     echo json_encode(['error' => 'missing fields']);
     exit;
-}
-
-function db(): PDO {
-    $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
-    $pdo = new PDO($dsn);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    return $pdo;
 }
 
 $pdo = db();

--- a/api/logout.php
+++ b/api/logout.php
@@ -3,6 +3,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../db.php';
+
 header('Content-Type: application/json');
 
 $sessionToken = $_SERVER['HTTP_X_SESSION_TOKEN'] ?? $_SERVER['HTTP_SESSION_TOKEN'] ?? '';
@@ -18,13 +20,6 @@ if ($sessionToken === '') {
     http_response_code(400);
     echo json_encode(['error' => 'missing session_token']);
     exit;
-}
-
-function db(): PDO {
-    $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
-    $pdo = new PDO($dsn);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    return $pdo;
 }
 
 $pdo = db();

--- a/api/market.php
+++ b/api/market.php
@@ -3,15 +3,9 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/_auth.php';
 require_once __DIR__ . '/_points.php';
+require_once __DIR__ . '/../db.php';
 
 header('Content-Type: application/json');
-
-function db(): PDO {
-  $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
-  $pdo = new PDO($dsn);
-  $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-  return $pdo;
-}
 
 function load_packs(): array {
   $path = realpath(__DIR__ . '/../packs.json');

--- a/api/matches_join.php
+++ b/api/matches_join.php
@@ -4,6 +4,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/_auth.php';
+require_once __DIR__ . '/../db.php';
 
 header('Content-Type: application/json');
 
@@ -19,13 +20,6 @@ if ($match_id <= 0) {
     http_response_code(400);
     echo json_encode(['error' => 'missing match_id'], JSON_UNESCAPED_UNICODE);
     exit;
-}
-
-function db(): PDO {
-    $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
-    $pdo = new PDO($dsn);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    return $pdo;
 }
 
 $pdo = db();

--- a/api/matches_list.php
+++ b/api/matches_list.php
@@ -4,15 +4,9 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/_auth.php';
+require_once __DIR__ . '/../db.php';
 
 header('Content-Type: application/json');
-
-function db(): PDO {
-    $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
-    $pdo = new PDO($dsn);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    return $pdo;
-}
 
 $pdo = db();
 $user = require_session($pdo);

--- a/api/matches_start.php
+++ b/api/matches_start.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/_auth.php';
 require_once __DIR__ . '/_game.php';
+require_once __DIR__ . '/../db.php';
 
 header('Content-Type: application/json');
 
@@ -21,13 +22,6 @@ if ($match_id <= 0) {
     http_response_code(400);
     echo json_encode(['error' => 'missing match_id'], JSON_UNESCAPED_UNICODE);
     exit;
-}
-
-function db(): PDO {
-    $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
-    $pdo = new PDO($dsn);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    return $pdo;
 }
 
 $pdo = db();

--- a/api/new_game.php
+++ b/api/new_game.php
@@ -4,6 +4,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/_game.php';
+require_once __DIR__ . '/../db.php';
 
 header('Content-Type: application/json');
 
@@ -23,13 +24,6 @@ if ($host_user_id <= 0 || !is_array($initial_state)) {
     http_response_code(400);
     echo json_encode(['error' => 'missing fields']);
     exit;
-}
-
-function db(): PDO {
-    $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
-    $pdo = new PDO($dsn);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    return $pdo;
 }
 
 try {

--- a/api/new_match.php
+++ b/api/new_match.php
@@ -4,15 +4,9 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/_auth.php';
+require_once __DIR__ . '/../db.php';
 
 header('Content-Type: application/json');
-
-function db(): PDO {
-    $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
-    $pdo = new PDO($dsn);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    return $pdo;
-}
 
 $input = json_decode(file_get_contents('php://input'), true);
 if (!is_array($input)) {

--- a/api/register.php
+++ b/api/register.php
@@ -3,6 +3,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../db.php';
+
 header('Content-Type: application/json');
 
 $input = json_decode(file_get_contents('php://input'), true);
@@ -18,13 +20,6 @@ if ($username === '' || $password === '') {
     http_response_code(400);
     echo json_encode(['error' => 'missing fields']);
     exit;
-}
-
-function db(): PDO {
-    $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
-    $pdo = new PDO($dsn);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    return $pdo;
 }
 
 $pdo = db();

--- a/api/state.php
+++ b/api/state.php
@@ -3,6 +3,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../db.php';
+
 header('Content-Type: application/json');
 
 $game_id = isset($_GET['game_id']) ? (int)$_GET['game_id'] : 0;
@@ -10,13 +12,6 @@ if ($game_id <= 0) {
     http_response_code(400);
     echo json_encode(['error' => 'missing game_id']);
     exit;
-}
-
-function db(): PDO {
-    $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
-    $pdo = new PDO($dsn);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    return $pdo;
 }
 
 $pdo = db();

--- a/api/stream.php
+++ b/api/stream.php
@@ -5,6 +5,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/../db.php';
+
 header('Content-Type: text/event-stream');
 header('Cache-Control: no-cache');
 
@@ -14,13 +16,6 @@ if ($game_id <= 0) {
     http_response_code(400);
     echo "data: {\"error\":\"missing game_id\"}\n\n";
     exit;
-}
-
-function db(): PDO {
-    $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
-    $pdo = new PDO($dsn);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    return $pdo;
 }
 
 $pdo = db();

--- a/db.php
+++ b/db.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+function db(): PDO {
+    static $pdo = null;
+    if ($pdo instanceof PDO) {
+        return $pdo;
+    }
+    $configPath = __DIR__ . '/config.php';
+    if (!file_exists($configPath)) {
+        throw new RuntimeException('Missing config.php');
+    }
+    $cfg = require $configPath;
+    $host = $cfg['db_host'] ?? 'localhost';
+    $port = $cfg['db_port'] ?? '5432';
+    $name = $cfg['db_name'] ?? 'dark_promoters';
+    $user = $cfg['db_user'] ?? '';
+    $pass = $cfg['db_pass'] ?? '';
+    $dsn = "pgsql:host={$host};port={$port};dbname={$name}";
+    $pdo = new PDO($dsn, $user, $pass, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    ]);
+    return $pdo;
+}

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -4,7 +4,7 @@ Follow these steps to get a local instance of **Dark Promoters** running.
 
 ## Prerequisites
 - PHP 8
-- MySQL or MariaDB
+- PostgreSQL
 
 ## Setup
 1. Clone this repository.

--- a/public/setup.php
+++ b/public/setup.php
@@ -1,0 +1,77 @@
+<?php
+// Web-based setup script to configure database and run migrations
+$default = [
+    'db_host' => 'localhost',
+    'db_port' => '5432',
+    'db_name' => 'dark_promoters',
+    'db_user' => 'postgres',
+];
+
+$success = false;
+$error = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $host = $_POST['db_host'] ?? $default['db_host'];
+    $port = $_POST['db_port'] ?? $default['db_port'];
+    $name = $_POST['db_name'] ?? $default['db_name'];
+    $user = $_POST['db_user'] ?? $default['db_user'];
+    $pass = $_POST['db_pass'] ?? '';
+
+    // Write config.php
+    $configContent = "<?php\nreturn [\n    'db_host' => '" . addslashes($host) . "',\n    'db_port' => '" . addslashes($port) . "',\n    'db_name' => '" . addslashes($name) . "',\n    'db_user' => '" . addslashes($user) . "',\n    'db_pass' => '" . addslashes($pass) . "',\n];\n";
+    $configPath = dirname(__DIR__) . '/config.php';
+    file_put_contents($configPath, $configContent);
+
+    try {
+        $cfg = require $configPath;
+        $serverDsn = "pgsql:host={$cfg['db_host']};port={$cfg['db_port']};dbname=postgres";
+        $pdo = new PDO($serverDsn, $cfg['db_user'], $cfg['db_pass'], [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+        try {
+            $pdo->exec('CREATE DATABASE "' . $cfg['db_name'] . '"');
+        } catch (PDOException $e) {
+            if ($e->getCode() !== '42P04') {
+                throw $e;
+            }
+        }
+        $dsn = "pgsql:host={$cfg['db_host']};port={$cfg['db_port']};dbname={$cfg['db_name']}";
+        $pdo = new PDO($dsn, $cfg['db_user'], $cfg['db_pass'], [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+        $migrationsDir = dirname(__DIR__) . '/migrations';
+        $files = glob($migrationsDir . '/*.sql');
+        natsort($files);
+        foreach ($files as $file) {
+            $sql = file_get_contents($file);
+            $pdo->exec($sql);
+        }
+        $success = true;
+    } catch (PDOException $e) {
+        $error = $e->getMessage();
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Dark Promoters Setup</title>
+</head>
+<body>
+<?php if ($success): ?>
+    <h1>Setup Complete</h1>
+    <p>Database configured and migrations applied.</p>
+    <p><a href="index.html">Go to application</a></p>
+<?php else: ?>
+    <h1>Dark Promoters Setup</h1>
+    <?php if ($error): ?>
+        <p style="color:red;">Error: <?= htmlspecialchars($error, ENT_QUOTES) ?></p>
+    <?php endif; ?>
+    <form method="post">
+        <label>DB host <input name="db_host" value="<?= htmlspecialchars($_POST['db_host'] ?? $default['db_host'], ENT_QUOTES) ?>"></label><br>
+        <label>DB port <input name="db_port" value="<?= htmlspecialchars($_POST['db_port'] ?? $default['db_port'], ENT_QUOTES) ?>"></label><br>
+        <label>DB name <input name="db_name" value="<?= htmlspecialchars($_POST['db_name'] ?? $default['db_name'], ENT_QUOTES) ?>"></label><br>
+        <label>DB user <input name="db_user" value="<?= htmlspecialchars($_POST['db_user'] ?? $default['db_user'], ENT_QUOTES) ?>"></label><br>
+        <label>DB pass <input type="password" name="db_pass"></label><br>
+        <button type="submit">Run Setup</button>
+    </form>
+<?php endif; ?>
+</body>
+</html>

--- a/tools/points_topup.php
+++ b/tools/points_topup.php
@@ -2,13 +2,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../api/_points.php';
-
-function db(): PDO {
-    $dsn = getenv('DATABASE_URL') ?: 'pgsql:host=localhost;dbname=dark_promoters';
-    $pdo = new PDO($dsn);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    return $pdo;
-}
+require_once __DIR__ . '/../db.php';
 
 $pdo = db();
 


### PR DESCRIPTION
## Summary
- add `db.php` that loads database credentials from `config.php` and returns a shared PDO connection
- update setup, API and tooling scripts to always read credentials from `config.php`
- document PostgreSQL requirement in README and onboarding

## Testing
- `php -l db.php setup.php public/setup.php tools/points_topup.php api/act.php api/decks.php api/end_game.php api/inventory.php api/login.php api/logout.php api/market.php api/matches_join.php api/matches_list.php api/matches_start.php api/new_game.php api/new_match.php api/register.php api/state.php api/stream.php`


------
https://chatgpt.com/codex/tasks/task_e_689d9c8a98248320af3a7be2e78fbe9f