### PR TITLE
feat: add browser setup form

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Players compete for **Locations, Acts, Sponsors, Marketing** and **Audience**. A
 ## Quick Start (dev)
 
 1. PHP 8 + MySQL or MariaDB installed.
-2. Run `php setup.php` and follow the prompts to create the database, apply migrations and write `config.php`. Alternatively, start a web server and visit `public/setup.php` for a graphical setup.
+2. Run `php setup.php` and follow the prompts to create the database, apply migrations and write `config.php`. Alternatively, start a web server and visit `setup.php` for a graphical setup.
 3. Serve repo root via `php -S localhost:8080` (or your web server).
 4. Open `http://localhost:8080`.
 

--- a/setup.php
+++ b/setup.php
@@ -1,67 +1,83 @@
 <?php
-// Interactive setup script to configure database and run migrations
+// Setup script to configure database and run migrations via CLI or web form
+
+function performSetup(string $host, string $port, string $name, string $user, string $pass): string {
+    $out = '';
+    $configContent = "<?php\nreturn [\n    'db_host' => '" . addslashes($host) . "',\n    'db_port' => '" . addslashes($port) . "',\n    'db_name' => '" . addslashes($name) . "',\n    'db_user' => '" . addslashes($user) . "',\n    'db_pass' => '" . addslashes($pass) . "',\n];\n";
+    file_put_contents(__DIR__ . '/config.php', $configContent);
+    $out .= "config.php written\n";
+
+    try {
+        $serverDsn = "mysql:host={$host};port={$port};charset=utf8mb4";
+        $pdo = new PDO($serverDsn, $user, $pass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+        $pdo->exec('CREATE DATABASE IF NOT EXISTS `'.$name.'` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci');
+        $dsn = "mysql:host={$host};port={$port};dbname={$name};charset=utf8mb4";
+        $pdo = new PDO($dsn, $user, $pass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+        $out .= "Database '{$name}' ready\n";
+
+        $migrationsDir = __DIR__ . '/migrations';
+        $files = glob($migrationsDir . '/*.sql');
+        natsort($files);
+        foreach ($files as $file) {
+            $sql = file_get_contents($file);
+            $out .= "Applying " . basename($file) . "...";
+            $pdo->exec($sql);
+            $out .= "done\n";
+        }
+        $out .= "Setup complete.\n";
+    } catch (PDOException $e) {
+        $out .= "Connection failed: " . $e->getMessage() . "\n";
+    }
+    return $out;
+}
+
+if (php_sapi_name() !== 'cli') {
+    $default = [
+        'db_host' => 'localhost',
+        'db_port' => '3306',
+        'db_name' => 'dark_promoters',
+        'db_user' => 'root',
+    ];
+    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        $host = $_POST['db_host'] ?? $default['db_host'];
+        $port = $_POST['db_port'] ?? $default['db_port'];
+        $name = $_POST['db_name'] ?? $default['db_name'];
+        $user = $_POST['db_user'] ?? $default['db_user'];
+        $pass = $_POST['db_pass'] ?? '';
+        $log = performSetup($host, $port, $name, $user, $pass);
+        echo '<!DOCTYPE html><html><body><pre>' . htmlspecialchars($log, ENT_QUOTES) . '</pre></body></html>';
+    } else {
+        echo '<!DOCTYPE html><html><body><form method="post">'
+            . '<label>DB host <input name="db_host" value="' . htmlspecialchars($default['db_host'], ENT_QUOTES) . '"></label><br>'
+            . '<label>DB port <input name="db_port" value="' . htmlspecialchars($default['db_port'], ENT_QUOTES) . '"></label><br>'
+            . '<label>DB name <input name="db_name" value="' . htmlspecialchars($default['db_name'], ENT_QUOTES) . '"></label><br>'
+            . '<label>DB user <input name="db_user" value="' . htmlspecialchars($default['db_user'], ENT_QUOTES) . '"></label><br>'
+            . '<label>DB pass <input type="password" name="db_pass"></label><br>'
+            . '<button type="submit">Run Setup</button>'
+            . '</form></body></html>';
+    }
+    return;
+}
 
 function prompt(string $prompt, string $default = ''): string {
     if ($default !== '') {
         $prompt .= " [$default]";
     }
     $prompt .= ': ';
-
-    // Use readline if available, otherwise read from STDIN
     if (function_exists('readline')) {
         $input = readline($prompt);
     } else {
         echo $prompt;
         $input = fgets(STDIN);
     }
-
     $input = $input === false ? '' : trim($input);
     return $input === '' ? $default : $input;
 }
 
-// Collect DB credentials
 $host = prompt('DB host', 'localhost');
-$port = prompt('DB port', '5432');
+$port = prompt('DB port', '3306');
 $name = prompt('DB name', 'dark_promoters');
-$user = prompt('DB user', 'postgres');
+$user = prompt('DB user', 'root');
 $pass = prompt('DB password');
 
-// Write config.php
-$configContent = "<?php\nreturn [\n    'db_host' => '" . addslashes($host) . "',\n    'db_port' => '" . addslashes($port) . "',\n    'db_name' => '" . addslashes($name) . "',\n    'db_user' => '" . addslashes($user) . "',\n    'db_pass' => '" . addslashes($pass) . "',\n];\n";
-file_put_contents(__DIR__ . '/config.php', $configContent);
-echo "config.php written\n";
-
-
-// Load config and connect to MySQL server
-$cfg = require __DIR__ . '/config.php';
-$dsnServer = "mysql:host={$cfg['db_host']};port={$cfg['db_port']};charset=utf8mb4";
-
-try {
-    $pdo = new PDO($dsnServer, $cfg['db_user'], $cfg['db_pass'], [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
-} catch (PDOException $e) {
-    fwrite(STDERR, "Connection failed: " . $e->getMessage() . "\n");
-    exit(1);
-}
-
-// Create database if not exists
-
-$pdo->exec('CREATE DATABASE IF NOT EXISTS `'.$cfg['db_name'].'` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci');
-
-// Connect to target database
-$dsn = "mysql:host={$cfg['db_host']};port={$cfg['db_port']};dbname={$cfg['db_name']};charset=utf8mb4";
-$pdo = new PDO($dsn, $cfg['db_user'], $cfg['db_pass'], [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
-
-echo "Database '{$cfg['db_name']}' ready\n";
-
-// Run migrations
-$migrationsDir = __DIR__ . '/migrations';
-$files = glob($migrationsDir . '/*.sql');
-natsort($files);
-foreach ($files as $file) {
-    $sql = file_get_contents($file);
-    echo "Applying " . basename($file) . "...";
-    $pdo->exec($sql);
-    echo "done\n";
-}
-
-echo "Setup complete.\n";
+echo performSetup($host, $port, $name, $user, $pass);


### PR DESCRIPTION
## Summary
- Support both CLI prompts and browser form in `setup.php`
- Document browser-based setup in quick start

## Testing
- `php -l setup.php`


------
https://chatgpt.com/codex/tasks/task_e_689db3a89ad883208d270e09e1f4c9ec