### PR TITLE
feat: toggle nav links by session

### DIFF
--- a/i18n/ui.de.json
+++ b/i18n/ui.de.json
@@ -32,6 +32,7 @@
   "buy_header": "Kaufen",
   "buy_button": "Kaufen",
   "purchase_failed": "Kauf fehlgeschlagen",
+  "deckbuilder_title": "Deckbauer",
   "matches_title": "Matches",
   "match_name_label": "Name:",
   "max_players_label": "Max. Spieler:",

--- a/i18n/ui.en.json
+++ b/i18n/ui.en.json
@@ -32,6 +32,7 @@
   "buy_header": "Buy",
   "buy_button": "Buy",
   "purchase_failed": "Purchase failed",
+  "deckbuilder_title": "Deck Builder",
   "matches_title": "Matches",
   "match_name_label": "Name:",
   "max_players_label": "Max players:",

--- a/public/auth.js
+++ b/public/auth.js
@@ -10,6 +10,14 @@ async function sendAuth(url, data) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  const authLinks = document.getElementById('auth_links');
+  const userLinks = document.getElementById('user_links');
+  if (authLinks && userLinks) {
+    const token = localStorage.getItem('session_token');
+    authLinks.style.display = token ? 'none' : '';
+    userLinks.style.display = token ? '' : 'none';
+  }
+
   const loginForm = document.getElementById('login_form');
   if (loginForm) {
     loginForm.addEventListener('submit', async (e) => {

--- a/public/index.html
+++ b/public/index.html
@@ -16,12 +16,19 @@
   <main>
     <h1 data-i18n="welcome_title">Dark Promoters</h1>
     <p data-i18n="intro_text">Organize gothic/alt-scene events and compete for the best show.</p>
-    <p>
+    <p id="auth_links">
       <a href="login.html" data-i18n="login_button">Login</a>
       <a href="register.html" data-i18n="register_button">Register</a>
     </p>
+    <p id="user_links">
+      <a href="inventory.html" data-i18n="inventory_title">Inventory</a>
+      <a href="market.html" data-i18n="market_title">Market</a>
+      <a href="deckbuilder.html" data-i18n="deckbuilder_title">Deck Builder</a>
+      <a href="matches.html" data-i18n="matches_title">Matches</a>
+    </p>
   </main>
   <script src="i18n.js"></script>
+  <script src="auth.js"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- Show login/register links or user links (inventory, market, deckbuilder, matches) on index based on stored session token
- Add simple auth check in auth.js to swap navigation visibility
- Include missing `deckbuilder_title` translations

## Testing
- `node --check public/auth.js && echo 'syntax ok'`
- `python -m json.tool i18n/ui.en.json | head -n 1`
- `python -m json.tool i18n/ui.de.json | head -n 1`


------
https://chatgpt.com/codex/tasks/task_e_689dc5b9fbc88320b67754a46eaf257a