### PR TITLE
Fix MySQL interval syntax in login session insertion

### DIFF
--- a/api/login.php
+++ b/api/login.php
@@ -34,7 +34,7 @@ if (!$user || !password_verify($password, $user['password_hash'])) {
 
 $sessionToken = bin2hex(random_bytes(32));
 $pdo->beginTransaction();
-$stmt = $pdo->prepare("INSERT INTO sessions (user_id, session_token, expires_at) VALUES (:uid, :token, NOW() + INTERVAL '7 days')");
+$stmt = $pdo->prepare("INSERT INTO sessions (user_id, session_token, expires_at) VALUES (:uid, :token, DATE_ADD(NOW(), INTERVAL 7 DAY))");
 $stmt->execute([
     ':uid' => (int)$user['id'],
     ':token' => $sessionToken,


### PR DESCRIPTION
## Summary
- fix login session expiration SQL to use `DATE_ADD(NOW(), INTERVAL 7 DAY)` for MySQL compatibility

## Testing
- `php -l api/login.php`


------
https://chatgpt.com/codex/tasks/task_e_689dc9191e108320a25877d80bd93718