### PR TITLE
Handle market and inventory API errors

### DIFF
--- a/public/inventory.js
+++ b/public/inventory.js
@@ -17,10 +17,18 @@ document.addEventListener('DOMContentLoaded', () => {
           'Authorization': `Bearer ${token}`
         }
       });
-      const json = await res.json();
-      inventory = json.inventory || [];
-      if (pointsEl) {
-        pointsEl.textContent = json.points || 0;
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || json.error) {
+        if (res.status === 401) {
+          window.location.href = 'login.html';
+        } else {
+          alert(json.error || (window.i18n ? window.i18n.t('load_failed') : 'Failed to load inventory'));
+        }
+        return;
+      }
+      inventory = Array.isArray(json.inventory) ? json.inventory : [];
+      if (pointsEl && typeof json.points === 'number') {
+        pointsEl.textContent = json.points;
       }
       render();
     } catch (err) {

--- a/public/market.js
+++ b/public/market.js
@@ -16,9 +16,19 @@ document.addEventListener('DOMContentLoaded', () => {
           'Authorization': `Bearer ${token}`
         }
       });
-      const json = await res.json();
-      pointsEl.textContent = json.points || 0;
-      packs = json.packs || [];
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || json.error) {
+        if (res.status === 401) {
+          window.location.href = 'login.html';
+        } else {
+          alert(json.error || (window.i18n ? window.i18n.t('load_failed') : 'Failed to load market'));
+        }
+        return;
+      }
+      if (typeof json.points === 'number') {
+        pointsEl.textContent = json.points;
+      }
+      packs = Array.isArray(json.packs) ? json.packs : [];
       render();
     } catch (err) {
       console.error(err);
@@ -40,7 +50,9 @@ document.addEventListener('DOMContentLoaded', () => {
         alert(json.error || (window.i18n ? window.i18n.t('purchase_failed') : 'Purchase failed'));
         return;
       }
-      pointsEl.textContent = json.points;
+      if (typeof json.points === 'number') {
+        pointsEl.textContent = json.points;
+      }
       if (json.awarded) {
         alert('Received: ' + json.awarded.join(', '));
       }


### PR DESCRIPTION
## Summary
- Guard market and inventory fetches against failed responses and redirect to login or alert when necessary
- Update points display only when server returns a valid value

## Testing
- `php tests/admin_endpoints_test.php`
- `php tests/admin_user_management_test.php`
- `php tests/require_admin_allows_admin.php`
- `php tests/require_admin_blocks_non_admin.php`

------
https://chatgpt.com/codex/tasks/task_e_689dd70a632c8320907d71fc4f8f5238