### PR TITLE
Require Authorization header for API sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Backend: simple API
 
     POST /api/login.php → {username, password} → returns session_token
 
-    POST /api/logout.php → Authorization or {session_token} → invalidate session
+    POST /api/logout.php → Authorization header → invalidate session
 
     GET /api/cards.php → loads/merges all card JSONs (recursive scan + APCu/ETag caching)
 
@@ -126,7 +126,7 @@ Frontend pages & example flow
 
   Example: register → log in → buy a starter pack → check new cards in inventory → build a deck → start a game.
 
-Session tokens are stored in the `sessions` table with an expiry and returned by `/api/login.php`. Clients persist the token (e.g., `localStorage`) and send it on requests via `Authorization: Bearer <token>` or a `session_token` parameter. `/api/logout.php` deletes the token. Ensure migrations `001_initial.sql` and `002_add_password_hash.sql` are applied before using these endpoints.
+Session tokens are stored in the `sessions` table with an expiry and returned by `/api/login.php`. Clients persist the token (e.g., `localStorage`) and send it on requests via `Authorization: Bearer <token>`. `/api/logout.php` deletes the token. Ensure migrations `001_initial.sql` and `002_add_password_hash.sql` are applied before using these endpoints.
 
 Game state is stored as JSON in the DB for quick iteration (games.state_json, versioned).
 Internationalization (EN/DE)

--- a/api/_auth.php
+++ b/api/_auth.php
@@ -2,28 +2,21 @@
 declare(strict_types=1);
 
 /**
- * Require a valid session based on Authorization header or session_token parameter.
+ * Require a valid session based on an Authorization header.
  *
  * @param PDO $db Database connection
  * @return array Authenticated user as ['id' => int, 'username' => string, 'is_admin' => int]
  */
 function require_session(PDO $db): array {
-    $token = '';
-
-    // Check Authorization: Bearer <token> header
+    // Expect Authorization: Bearer <token>
     $authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
-    if (stripos($authHeader, 'Bearer ') === 0) {
-        $token = substr($authHeader, 7);
+    if (stripos($authHeader, 'Bearer ') !== 0) {
+        http_response_code(401);
+        echo json_encode(['error' => 'missing Authorization header'], JSON_UNESCAPED_UNICODE);
+        exit;
     }
 
-    // Fallback to session_token parameter (GET/POST)
-    if ($token === '') {
-        $param = $_REQUEST['session_token'] ?? '';
-        if (is_string($param)) {
-            $token = $param;
-        }
-    }
-
+    $token = trim(substr($authHeader, 7));
     if ($token === '') {
         http_response_code(401);
         echo json_encode(['error' => 'missing session token'], JSON_UNESCAPED_UNICODE);

--- a/api/logout.php
+++ b/api/logout.php
@@ -7,18 +7,17 @@ require_once __DIR__ . '/../db.php';
 
 header('Content-Type: application/json');
 
-$sessionToken = $_SERVER['HTTP_X_SESSION_TOKEN'] ?? $_SERVER['HTTP_SESSION_TOKEN'] ?? '';
-if ($sessionToken === '') {
-    $input = json_decode(file_get_contents('php://input'), true);
-    if (is_array($input)) {
-        $sessionToken = trim((string)($input['session_token'] ?? ''));
-    }
+$authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+if (stripos($authHeader, 'Bearer ') !== 0) {
+    http_response_code(401);
+    echo json_encode(['error' => 'missing Authorization header'], JSON_UNESCAPED_UNICODE);
+    exit;
 }
 
-$sessionToken = trim($sessionToken);
+$sessionToken = trim(substr($authHeader, 7));
 if ($sessionToken === '') {
-    http_response_code(400);
-    echo json_encode(['error' => 'missing session_token']);
+    http_response_code(401);
+    echo json_encode(['error' => 'missing session token'], JSON_UNESCAPED_UNICODE);
     exit;
 }
 

--- a/public/auth.js
+++ b/public/auth.js
@@ -80,10 +80,8 @@ document.addEventListener('DOMContentLoaded', () => {
         await fetch('/api/logout.php', {
           method: 'POST',
           headers: {
-            'Content-Type': 'application/json',
             'Authorization': token ? `Bearer ${token}` : ''
-          },
-          body: JSON.stringify({ session_token: token })
+          }
         });
       } catch (err) {
         console.error(err);


### PR DESCRIPTION
## Summary
- enforce Bearer token in Authorization header for session validation
- adjust logout endpoint and frontend to stop using `session_token` parameter
- refresh docs to describe header-only auth flow

## Testing
- `php tests/require_admin_allows_admin.php`
- `php tests/require_admin_blocks_non_admin.php`
- `php tests/admin_endpoints_test.php`
- `php tests/admin_user_management_test.php`


------
https://chatgpt.com/codex/tasks/task_e_689de600a1a08320abc4bcb3d1c9530c