### PR TITLE
Add PHP controllers and update navigation links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ This document splits the work into clear roles so humans (and code agents) can c
 - **Acceptance:** `api/cards.php` returns stable structure; invalid cards skipped with warnings; per-card files OK.
 
 ### 3) Frontend Renderer
-- **Owns:** `/public/index.html`, `cards.css`, `app.js`.
+- **Owns:** `/public/index.php`, `cards.css`, `app.js`.
 - **Tasks:** Render MTG-like frames; EN/DE toggle; lazy-load art; later drag/drop onto table.
 - **Acceptance:** Cards display with frame/bg/art/title/type/rules/rarity; locale switch updates text; no layout regressions.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For detailed onboarding steps see `docs/ONBOARDING.md`.
 /cards/        # one JSON per card
 /starter_decks/# sample starter decks
 /i18n/        # ui.en.json, ui.de.json (UI strings)
-/public/       # index.html, cards.css, app.js
+/public/       # index.php, cards.css, app.js
 /docs/         # RULES.md (EN), RULES.de.md (DE), ONBOARDING.md, CONTRIBUTING.md, AGENTS.md
 /migrations/   # SQL schema migrations
 /rulesets/     # versioned ruleset JSON
@@ -116,13 +116,13 @@ Inventory & Deck Building APIs
 
 Frontend pages & example flow
 
-    - `/public/register.html` – create account
-    - `/public/login.html` – sign in
-    - `/public/market.html` – buy packs
-    - `/public/inventory.html` – view owned cards
-    - `/public/deckbuilder.html` – assemble decks
-    - `/public/index.html` – play a game
-    - `/public/admin.html` – admin dashboard for user/points management (requires admin account)
+    - `/public/register.php` – create account
+    - `/public/login.php` – sign in
+    - `/public/market.php` – buy packs
+    - `/public/inventory.php` – view owned cards
+    - `/public/deckbuilder.php` – assemble decks
+    - `/public/index.php` – play a game
+    - `/public/admin.php` – admin dashboard for user/points management (requires admin account)
 
   Example: register → log in → buy a starter pack → check new cards in inventory → build a deck → start a game.
 

--- a/public/admin.js
+++ b/public/admin.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const token = localStorage.getItem('session_token');
   if (!token) {
-    window.location.href = 'login.html';
+    window.location.href = 'login.php';
     return;
   }
   const output = document.getElementById('admin_output');

--- a/public/admin.php
+++ b/public/admin.php
@@ -1,0 +1,5 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../src/page.php';
+
+render_page('admin.tpl');

--- a/public/auth.js
+++ b/public/auth.js
@@ -42,7 +42,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const json = await sendAuth('/api/login.php', payload);
         if (json.session_token) {
           localStorage.setItem('session_token', json.session_token);
-          window.location.href = 'index.html';
+          window.location.href = 'index.php';
         } else {
           alert(json.error || (window.i18n ? window.i18n.t('login_failed') : 'Login failed'));
         }
@@ -62,7 +62,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const json = await sendAuth('/api/register.php', payload);
         if (json.session_token) {
           localStorage.setItem('session_token', json.session_token);
-          window.location.href = 'index.html';
+          window.location.href = 'index.php';
         } else {
           alert(json.error || (window.i18n ? window.i18n.t('registration_failed') : 'Registration failed'));
         }
@@ -87,7 +87,7 @@ document.addEventListener('DOMContentLoaded', () => {
         console.error(err);
       } finally {
         localStorage.removeItem('session_token');
-        window.location.href = 'login.html';
+        window.location.href = 'login.php';
       }
     });
   }

--- a/public/deckbuilder.js
+++ b/public/deckbuilder.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const token = localStorage.getItem('session_token');
   if (!token) {
-    window.location.href = 'login.html';
+    window.location.href = 'login.php';
     return;
   }
 

--- a/public/deckbuilder.php
+++ b/public/deckbuilder.php
@@ -1,0 +1,5 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../src/page.php';
+
+render_page('deckbuilder.tpl');

--- a/public/game.php
+++ b/public/game.php
@@ -1,0 +1,5 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../src/page.php';
+
+render_page('game.tpl');

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../src/page.php';
+
+$userLinks = [
+    ['href' => 'inventory.php', 'text' => 'Inventory', 'key' => 'inventory_button'],
+    ['href' => 'market.php', 'text' => 'Market', 'key' => 'market_button'],
+    ['href' => 'deckbuilder.php', 'text' => 'Deck Builder', 'key' => 'deckbuilder_button'],
+    ['href' => 'matches.php', 'text' => 'Matches', 'key' => 'matches_button'],
+];
+render_page('index.tpl', ['user_links' => $userLinks]);

--- a/public/inventory.js
+++ b/public/inventory.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const token = localStorage.getItem('session_token');
   if (!token) {
-    window.location.href = 'login.html';
+    window.location.href = 'login.php';
     return;
   }
 
@@ -20,7 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const json = await res.json().catch(() => ({}));
       if (!res.ok || json.error) {
         if (res.status === 401) {
-          window.location.href = 'login.html';
+          window.location.href = 'login.php';
         } else {
           alert(json.error || (window.i18n ? window.i18n.t('load_failed') : 'Failed to load inventory'));
         }

--- a/public/inventory.php
+++ b/public/inventory.php
@@ -1,0 +1,5 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../src/page.php';
+
+render_page('inventory.tpl');

--- a/public/login.php
+++ b/public/login.php
@@ -1,0 +1,5 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../src/page.php';
+
+render_page('login.tpl');

--- a/public/market.js
+++ b/public/market.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const token = localStorage.getItem('session_token');
   if (!token) {
-    window.location.href = 'login.html';
+    window.location.href = 'login.php';
     return;
   }
 
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const json = await res.json().catch(() => ({}));
       if (!res.ok || json.error) {
         if (res.status === 401) {
-          window.location.href = 'login.html';
+          window.location.href = 'login.php';
         } else {
           alert(json.error || (window.i18n ? window.i18n.t('load_failed') : 'Failed to load market'));
         }

--- a/public/market.php
+++ b/public/market.php
@@ -1,0 +1,5 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../src/page.php';
+
+render_page('market.tpl');

--- a/public/matches.js
+++ b/public/matches.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const token = localStorage.getItem('session_token');
   if (!token) {
-    window.location.href = 'login.html';
+    window.location.href = 'login.php';
     return;
   }
 

--- a/public/matches.php
+++ b/public/matches.php
@@ -1,0 +1,5 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../src/page.php';
+
+render_page('matches.tpl');

--- a/public/register.php
+++ b/public/register.php
@@ -1,0 +1,5 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../src/page.php';
+
+render_page('register.tpl');

--- a/public/setup.php
+++ b/public/setup.php
@@ -56,7 +56,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <?php if ($success): ?>
     <h1>Setup Complete</h1>
     <p>Database configured and migrations applied.</p>
-    <p><a href="index.html">Go to application</a></p>
+    <p><a href="index.php">Go to application</a></p>
 <?php else: ?>
     <h1>Dark Promoters Setup</h1>
     <?php if ($error): ?>

--- a/src/page.php
+++ b/src/page.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../db.php';
+
+function current_user(PDO $pdo): ?array {
+    $token = $_COOKIE['session_token'] ?? '';
+    if ($token === '') {
+        return null;
+    }
+    $stmt = $pdo->prepare('SELECT u.id, u.username, u.is_admin FROM sessions s JOIN users u ON s.user_id = u.id WHERE s.session_token = ? AND s.expires_at > NOW()');
+    $stmt->execute([$token]);
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$user) {
+        return null;
+    }
+    return [
+        'id' => (int)$user['id'],
+        'username' => $user['username'],
+        'is_admin' => (int)$user['is_admin'],
+    ];
+}
+
+function load_translations(string $locale): array {
+    $baseFile = __DIR__ . '/../i18n/ui.en.json';
+    $base = json_decode(@file_get_contents($baseFile), true) ?: [];
+    if ($locale !== 'en') {
+        $localeFile = __DIR__ . '/../i18n/ui.' . $locale . '.json';
+        if (is_file($localeFile)) {
+            $extra = json_decode(@file_get_contents($localeFile), true) ?: [];
+            $base = array_merge($base, $extra);
+        }
+    }
+    return $base;
+}
+
+function render_page(string $template, array $vars = []): void {
+    $smarty = require __DIR__ . '/bootstrap.php';
+    $pdo = db();
+    $locale = $_COOKIE['locale'] ?? 'en';
+    $translations = load_translations($locale);
+    $user = current_user($pdo);
+    $smarty->assign('i18n', $translations);
+    $smarty->assign('user', $user);
+    $smarty->assign('is_logged_in', $user !== null);
+    $smarty->assign('show_admin', $user && $user['is_admin'] === 1);
+    foreach ($vars as $k => $v) {
+        $smarty->assign($k, $v);
+    }
+    $smarty->display($template);
+}

--- a/templates/index.tpl
+++ b/templates/index.tpl
@@ -9,13 +9,13 @@
       <a href="{$link.href}" data-i18n="{$link.key}">{$link.text}</a>
       {/foreach}
       {if $show_admin}
-      <a id="admin_link" href="admin.html">Admin</a>
+      <a id="admin_link" href="admin.php">Admin</a>
       {/if}
     </p>
     {else}
     <p id="auth_links">
-      <a href="login.html" data-i18n="login_button">Login</a>
-      <a href="register.html" data-i18n="register_button">Register</a>
+      <a href="login.php" data-i18n="login_button">Login</a>
+      <a href="register.php" data-i18n="register_button">Register</a>
     </p>
     {/if}
   </main>

--- a/templates/login.tpl
+++ b/templates/login.tpl
@@ -12,6 +12,6 @@
     <br>
     <button type="submit" data-i18n="login_button">Login</button>
   </form>
-  <p><span data-i18n="no_account">No account?</span> <a href="register.html" data-i18n="register_link">Register</a></p>
+  <p><span data-i18n="no_account">No account?</span> <a href="register.php" data-i18n="register_link">Register</a></p>
 {/capture}
 {include file='layout.tpl' title=$title scripts=['i18n.js','auth.js'] content=$smarty.capture.content}

--- a/templates/register.tpl
+++ b/templates/register.tpl
@@ -12,6 +12,6 @@
     <br>
     <button type="submit" data-i18n="register_button">Register</button>
   </form>
-  <p><span data-i18n="already_have_account">Already have an account?</span> <a href="login.html" data-i18n="login_link">Login</a></p>
+  <p><span data-i18n="already_have_account">Already have an account?</span> <a href="login.php" data-i18n="login_link">Login</a></p>
 {/capture}
 {include file='layout.tpl' title=$title scripts=['i18n.js','auth.js'] content=$smarty.capture.content}


### PR DESCRIPTION
## Summary
- Introduce shared `render_page` helper to load sessions and i18n strings into Smarty.
- Replace static HTML with PHP controllers for all templates and update navigation references.
- Refresh docs and scripts to reference new `.php` routes.

## Testing
- `php tests/require_session_accepts_redirect_header.php`
- `php tests/require_admin_blocks_non_admin.php; echo`
- `php tests/require_admin_allows_admin.php; echo`
- `php tests/admin_endpoints_test.php`
- `php tests/admin_user_management_test.php`


------
https://chatgpt.com/codex/tasks/task_e_689ed58d34fc8320bd76c498dd992ca2