### PR TITLE
Render setup form via Smarty and document templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@ Players compete for **Locations, Acts, Sponsors, Marketing** and **Audience**. A
 
 For detailed onboarding steps see `docs/ONBOARDING.md`.
 
+## Using Smarty templates
+
+### Installation
+
+Run `composer install` to fetch dependencies, including [Smarty](https://www.smarty.net/).
+
+### Directory structure
+
+- `/templates/` – view templates (`.tpl` files)
+- `/templates_c/` – compiled templates, generated automatically
+
+### Creating a new view
+
+1. Create a template in `/templates`, e.g. `example.tpl`.
+2. In your PHP script, load Smarty via `require __DIR__ . '/../src/bootstrap.php';`.
+3. Assign variables with `$smarty->assign('name', $value);` and render with `$smarty->display('example.tpl');`.
+
 ## Repository Layout (proposed)
 
 /api/          # PHP endpoints (state, actions, cards loader, SSE)

--- a/public/setup.php
+++ b/public/setup.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 $smarty = require __DIR__ . '/../src/bootstrap.php';
 
 // Web-based setup script to configure database and run migrations
@@ -9,18 +11,21 @@ $default = [
     'db_user' => 'root',
 ];
 
+$values = [
+    'db_host' => $_POST['db_host'] ?? $default['db_host'],
+    'db_port' => $_POST['db_port'] ?? $default['db_port'],
+    'db_name' => $_POST['db_name'] ?? $default['db_name'],
+    'db_user' => $_POST['db_user'] ?? $default['db_user'],
+];
+
 $success = false;
 $error = null;
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $host = $_POST['db_host'] ?? $default['db_host'];
-    $port = $_POST['db_port'] ?? $default['db_port'];
-    $name = $_POST['db_name'] ?? $default['db_name'];
-    $user = $_POST['db_user'] ?? $default['db_user'];
     $pass = $_POST['db_pass'] ?? '';
 
     // Write config.php
-    $configContent = "<?php\nreturn [\n    'db_host' => '" . addslashes($host) . "',\n    'db_port' => '" . addslashes($port) . "',\n    'db_name' => '" . addslashes($name) . "',\n    'db_user' => '" . addslashes($user) . "',\n    'db_pass' => '" . addslashes($pass) . "',\n];\n";
+    $configContent = "<?php\nreturn [\n    'db_host' => '" . addslashes($values['db_host']) . "',\n    'db_port' => '" . addslashes($values['db_port']) . "',\n    'db_name' => '" . addslashes($values['db_name']) . "',\n    'db_user' => '" . addslashes($values['db_user']) . "',\n    'db_pass' => '" . addslashes($pass) . "',\n];\n";
     $configPath = dirname(__DIR__) . '/config.php';
     file_put_contents($configPath, $configContent);
 
@@ -45,31 +50,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $error = $e->getMessage();
     }
 }
-?>
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Dark Promoters Setup</title>
-</head>
-<body>
-<?php if ($success): ?>
-    <h1>Setup Complete</h1>
-    <p>Database configured and migrations applied.</p>
-    <p><a href="index.php">Go to application</a></p>
-<?php else: ?>
-    <h1>Dark Promoters Setup</h1>
-    <?php if ($error): ?>
-        <p style="color:red;">Error: <?= htmlspecialchars($error, ENT_QUOTES) ?></p>
-    <?php endif; ?>
-    <form method="post">
-        <label>DB host <input name="db_host" value="<?= htmlspecialchars($_POST['db_host'] ?? $default['db_host'], ENT_QUOTES) ?>"></label><br>
-        <label>DB port <input name="db_port" value="<?= htmlspecialchars($_POST['db_port'] ?? $default['db_port'], ENT_QUOTES) ?>"></label><br>
-        <label>DB name <input name="db_name" value="<?= htmlspecialchars($_POST['db_name'] ?? $default['db_name'], ENT_QUOTES) ?>"></label><br>
-        <label>DB user <input name="db_user" value="<?= htmlspecialchars($_POST['db_user'] ?? $default['db_user'], ENT_QUOTES) ?>"></label><br>
-        <label>DB pass <input type="password" name="db_pass"></label><br>
-        <button type="submit">Run Setup</button>
-    </form>
-<?php endif; ?>
-</body>
-</html>
+
+$smarty->assign('success', $success);
+$smarty->assign('error', $error);
+$smarty->assign('values', $values);
+$smarty->display('setup.tpl');
+

--- a/templates/setup.tpl
+++ b/templates/setup.tpl
@@ -1,0 +1,23 @@
+{assign var='title' value='Dark Promoters Setup'}
+{capture name='content'}
+  {if $success}
+    <h1>Setup Complete</h1>
+    <p>Database configured and migrations applied.</p>
+    <p><a href="index.php">Go to application</a></p>
+  {else}
+    <h1>Dark Promoters Setup</h1>
+    {if $error}
+      <p style="color:red;">Error: {$error|escape}</p>
+    {/if}
+    <form method="post">
+      <label>DB host <input name="db_host" value="{$values.db_host|escape}"></label><br>
+      <label>DB port <input name="db_port" value="{$values.db_port|escape}"></label><br>
+      <label>DB name <input name="db_name" value="{$values.db_name|escape}"></label><br>
+      <label>DB user <input name="db_user" value="{$values.db_user|escape}"></label><br>
+      <label>DB pass <input type="password" name="db_pass"></label><br>
+      <button type="submit">Run Setup</button>
+    </form>
+  {/if}
+{/capture}
+{include file='layout.tpl' title=$title content=$smarty.capture.content}
+


### PR DESCRIPTION
## Summary
- Refactor setup script to hand form rendering to Smarty template
- Add setup.tpl for success message and configuration form
- Document Smarty template installation, structure, and usage in README

## Testing
- `composer install`
- `php tests/admin_endpoints_test.php`
- `php tests/admin_user_management_test.php`
- `php tests/require_admin_allows_admin.php`
- `php tests/require_admin_blocks_non_admin.php`
- `php tests/require_session_accepts_redirect_header.php`


------
https://chatgpt.com/codex/tasks/task_e_689ed81d2f6483209c1b4913d50c4769