### PR TITLE
Persist session token in cookie

### DIFF
--- a/api/login.php
+++ b/api/login.php
@@ -43,6 +43,13 @@ $stmt->execute([
 ]);
 $pdo->commit();
 
+setcookie('session_token', $sessionToken, [
+    'expires' => time() + 60 * 60 * 24 * 7,
+    'path' => '/',
+    'httponly' => true,
+    'samesite' => 'Lax',
+]);
+
 $response = [
     'session_token' => $sessionToken,
     'user' => [

--- a/api/logout.php
+++ b/api/logout.php
@@ -37,5 +37,7 @@ require_session($pdo);
 $stmt = $pdo->prepare('DELETE FROM sessions WHERE session_token = ?');
 $stmt->execute([$sessionToken]);
 
+setcookie('session_token', '', time() - 3600, '/');
+
 echo json_encode(['success' => true], JSON_UNESCAPED_UNICODE);
 

--- a/public/auth.js
+++ b/public/auth.js
@@ -42,6 +42,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const json = await sendAuth('/api/login.php', payload);
         if (json.session_token) {
           localStorage.setItem('session_token', json.session_token);
+          document.cookie = `session_token=${json.session_token}; Max-Age=604800; Path=/; SameSite=Lax`;
           window.location.href = '/index.php';
         } else {
           alert(json.error || (window.i18n ? window.i18n.t('login_failed') : 'Login failed'));
@@ -62,6 +63,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const json = await sendAuth('/api/register.php', payload);
         if (json.session_token) {
           localStorage.setItem('session_token', json.session_token);
+          document.cookie = `session_token=${json.session_token}; Max-Age=604800; Path=/; SameSite=Lax`;
           window.location.href = '/index.php';
         } else {
           alert(json.error || (window.i18n ? window.i18n.t('registration_failed') : 'Registration failed'));
@@ -86,6 +88,7 @@ document.addEventListener('DOMContentLoaded', () => {
       } catch (err) {
         console.error(err);
       } finally {
+        document.cookie = 'session_token=; Max-Age=0; Path=/; SameSite=Lax';
         localStorage.removeItem('session_token');
         window.location.href = '/public/login.php';
       }


### PR DESCRIPTION
## Summary
- Set session cookie after successful login
- Clear session cookie on logout
- Sync client cookie with session token changes

## Testing
- `for f in tests/*.php; do php "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_689eea7a7bcc83209fca93d276140f03