### PR TITLE
Fix session auth fallback for market and inventory

### DIFF
--- a/public/inventory.js
+++ b/public/inventory.js
@@ -10,13 +10,14 @@ document.addEventListener('DOMContentLoaded', () => {
   const pointsEl = document.getElementById('points');
   let inventory = [];
 
-  async function loadInventory() {
-    try {
-      const res = await fetch('/api/inventory.php', {
-        headers: {
-          'Authorization': `Bearer ${token}`
-        }
-      });
+    async function loadInventory() {
+      try {
+        const res = await fetch('/api/inventory.php', {
+          headers: {
+            'Authorization': `Bearer ${token}`
+          },
+          credentials: 'same-origin'
+        });
       const json = await res.json().catch(() => ({}));
       if (!res.ok || json.error) {
         if (res.status === 401) {

--- a/public/market.js
+++ b/public/market.js
@@ -9,13 +9,14 @@ document.addEventListener('DOMContentLoaded', () => {
   const tbody = document.getElementById('packs_body');
   let packs = [];
 
-  async function load() {
-    try {
-      const res = await fetch('/api/market.php', {
-        headers: {
-          'Authorization': `Bearer ${token}`
-        }
-      });
+    async function load() {
+      try {
+        const res = await fetch('/api/market.php', {
+          headers: {
+            'Authorization': `Bearer ${token}`
+          },
+          credentials: 'same-origin'
+        });
       const json = await res.json().catch(() => ({}));
       if (!res.ok || json.error) {
         if (res.status === 401) {
@@ -37,14 +38,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function buy(id) {
     try {
-      const res = await fetch('/api/market.php', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
-        },
-        body: JSON.stringify({ pack_id: id })
-      });
+        const res = await fetch('/api/market.php', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}`
+          },
+          credentials: 'same-origin',
+          body: JSON.stringify({ pack_id: id })
+        });
       const json = await res.json();
       if (json.error) {
         alert(json.error || (window.i18n ? window.i18n.t('purchase_failed') : 'Purchase failed'));

--- a/tests/require_session_accepts_cookie.php
+++ b/tests/require_session_accepts_cookie.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../api/_auth.php';
+
+$pdo = new PDO('sqlite::memory:');
+$pdo->sqliteCreateFunction('NOW', fn() => date('Y-m-d H:i:s'));
+$pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT, password_hash TEXT, is_admin TINYINT)');
+$pdo->exec('CREATE TABLE sessions (user_id INTEGER, session_token TEXT, expires_at TEXT)');
+$pdo->exec("INSERT INTO users (id, username, is_admin) VALUES (1, 'admin', 1)");
+$pdo->exec("INSERT INTO sessions (user_id, session_token, expires_at) VALUES (1, 'cookietoken', DATETIME('now', '+1 hour'))");
+
+unset($_SERVER['HTTP_AUTHORIZATION'], $_SERVER['REDIRECT_HTTP_AUTHORIZATION']);
+$_COOKIE['session_token'] = 'cookietoken';
+
+$user = require_session($pdo);
+if ($user['id'] === 1) {
+    echo "cookie ok\n";
+}


### PR DESCRIPTION
## Summary
- accept `session_token` cookie as fallback when `Authorization` header is missing
- include credentials in market/inventory fetch calls
- add test covering cookie-based session authentication

## Testing
- `php tests/admin_endpoints_test.php` *(fails: Failed opening required '/workspace/dark-promoters/src/../vendor/autoload.php')*
- `php tests/admin_user_management_test.php` *(fails: Failed opening required '/workspace/dark-promoters/src/../vendor/autoload.php')*
- `php tests/require_admin_allows_admin.php`
- `php tests/require_admin_blocks_non_admin.php`
- `php tests/require_session_accepts_cookie.php`
- `php tests/require_session_accepts_redirect_header.php`
- `php -l api/_auth.php tests/require_session_accepts_cookie.php`
- `node --check public/market.js public/inventory.js`


------
https://chatgpt.com/codex/tasks/task_e_689eec8b95f8832096c96c67759964a1