### PR TITLE
Handle non-JSON responses when buying packs

### DIFF
--- a/public/market.js
+++ b/public/market.js
@@ -47,8 +47,8 @@ document.addEventListener('DOMContentLoaded', () => {
           credentials: 'same-origin',
           body: JSON.stringify({ pack_id: id })
         });
-      const json = await res.json();
-      if (json.error) {
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || json.error) {
         alert(json.error || (window.i18n ? window.i18n.t('purchase_failed') : 'Purchase failed'));
         return;
       }


### PR DESCRIPTION
## Summary
- Make market purchase error handling robust against malformed or error responses

## Testing
- `for f in tests/*.php; do php "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_689ef1da515883208625360fa1353512