### PR TITLE
Use MySQL upsert for card inventory

### DIFF
--- a/api/market.php
+++ b/api/market.php
@@ -95,7 +95,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         break;
       }
       $cardId = $choices[array_rand($choices)];
-      $stmt = $pdo->prepare('INSERT INTO card_inventory (user_id, card_id, qty) VALUES (:uid, :cid, 1) ON CONFLICT (user_id, card_id) DO UPDATE SET qty = card_inventory.qty + 1');
+      $stmt = $pdo->prepare('INSERT INTO card_inventory (user_id, card_id, qty) VALUES (:uid, :cid, 1) ON DUPLICATE KEY UPDATE qty = qty + 1');
       $stmt->execute([':uid' => $user['id'], ':cid' => $cardId]);
       $awarded[] = $cardId;
     }


### PR DESCRIPTION
## Summary
- Replace Postgres-style `ON CONFLICT` with MySQL `ON DUPLICATE KEY UPDATE` when adding cards to inventory

## Testing
- `php tests/admin_endpoints_test.php`
- `php tests/admin_user_management_test.php`
- `php tests/require_admin_allows_admin.php`
- `php tests/require_admin_blocks_non_admin.php`
- `php tests/require_session_accepts_cookie.php`
- `php tests/require_session_accepts_redirect_header.php`
- `curl -s -X POST http://127.0.0.1:8000/api/market.php -H 'Authorization: Bearer token123' -H 'Content-Type: application/json' -d '{"pack_id":"starter_pack"}'`
- `mysql --socket=/tmp/mysql.sock -u root dark_promoters -e "SELECT user_id, card_id, qty FROM card_inventory;"`
- `mysql --socket=/tmp/mysql.sock -u root dark_promoters -e "SELECT id, points FROM users;"`


------
https://chatgpt.com/codex/tasks/task_e_689ef81425948320b5b3a4ad57fd521f