### PR TITLE
Add deck deletion to deck builder

### DIFF
--- a/public/deckbuilder.js
+++ b/public/deckbuilder.js
@@ -10,6 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const deckNameInput = document.getElementById('deck_name');
   const deckListSelect = document.getElementById('deck_list_select');
   const saveBtn = document.getElementById('save_btn');
+  const deleteBtn = document.getElementById('delete_btn');
 
   let inventory = [];
   const deck = {};
@@ -96,6 +97,30 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
+  async function deleteDeck(id) {
+    try {
+      const res = await fetch(`/api/decks.php?id=${id}`, {
+        method: 'DELETE',
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      const json = await res.json();
+      if (json.error) {
+        alert(json.error);
+      } else {
+        alert('Deck deleted');
+        Object.keys(deck).forEach(k => delete deck[k]);
+        deckNameInput.value = '';
+        currentDeckId = null;
+        renderDeck();
+        await loadDecks();
+        deckListSelect.value = '';
+        deleteBtn.style.display = 'none';
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
   deckListSelect.addEventListener('change', async () => {
     const id = deckListSelect.value;
     if (!id) {
@@ -103,6 +128,7 @@ document.addEventListener('DOMContentLoaded', () => {
       deckNameInput.value = '';
       Object.keys(deck).forEach(k => delete deck[k]);
       renderDeck();
+      deleteBtn.style.display = 'none';
       return;
     }
     try {
@@ -117,6 +143,7 @@ document.addEventListener('DOMContentLoaded', () => {
         deck[c.card_id] = c.qty;
       });
       renderDeck();
+      deleteBtn.style.display = 'inline-block';
     } catch (err) {
       console.error(err);
     }
@@ -151,10 +178,15 @@ document.addEventListener('DOMContentLoaded', () => {
         renderDeck();
         await loadDecks();
         deckListSelect.value = '';
+        deleteBtn.style.display = 'none';
       }
     } catch (err) {
       console.error(err);
     }
+  });
+
+  deleteBtn.addEventListener('click', () => {
+    if (currentDeckId) deleteDeck(currentDeckId);
   });
 
   loadInventory();

--- a/templates/deckbuilder.tpl
+++ b/templates/deckbuilder.tpl
@@ -5,6 +5,7 @@
     <select id="deck_list_select" class="form-select mb-3"></select>
     <input type="text" id="deck_name" class="form-control mb-3" data-i18n-placeholder="deck_name_placeholder" placeholder="Deck name">
     <button id="save_btn" class="btn btn-primary mb-4" data-i18n="save_deck_button">Save Deck</button>
+    <button id="delete_btn" class="btn btn-danger mb-4" style="display:none" data-i18n="delete_deck_button">Delete Deck</button>
     <h2 class="mt-4" data-i18n="inventory_header">Inventory</h2>
     <div id="inventory_list" class="inventory"></div>
     <h2 class="mt-4" data-i18n="deck_header">Deck</h2>


### PR DESCRIPTION
## Summary
- Add Delete Deck button to deck builder template
- Implement `deleteDeck` in deckbuilder.js to call API and refresh list
- Show/hide delete button based on loaded deck and clear form after save/delete

## Testing
- `node --check public/deckbuilder.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f043743bc8320989ddbad17652e99