### PR TITLE
Define per-mode rules in default rulesets

### DIFF
--- a/rulesets/default.v1.json
+++ b/rulesets/default.v1.json
@@ -3,5 +3,30 @@
   "id": "default.v1",
   "features": {},
   "global": {},
-  "modes": {}
+  "modes": {
+    "club": {
+      "rounds": 2,
+      "startBudget": 1000,
+      "ticketPriceDefault": 10,
+      "audienceBase": 200
+    },
+    "party": {
+      "rounds": 2,
+      "startBudget": 1500,
+      "ticketPriceDefault": 15,
+      "audienceBase": 300
+    },
+    "1day": {
+      "rounds": 3,
+      "startBudget": 3000,
+      "ticketPriceDefault": 20,
+      "audienceBase": 600
+    },
+    "2day": {
+      "rounds": 3,
+      "startBudget": 5000,
+      "ticketPriceDefault": 25,
+      "audienceBase": 800
+    }
+  }
 }

--- a/rulesets/default.v2.json
+++ b/rulesets/default.v2.json
@@ -5,5 +5,30 @@
   "global": {
     "winReward": 100
   },
-  "modes": {}
+  "modes": {
+    "club": {
+      "rounds": 2,
+      "startBudget": 1000,
+      "ticketPriceDefault": 10,
+      "audienceBase": 200
+    },
+    "party": {
+      "rounds": 2,
+      "startBudget": 1500,
+      "ticketPriceDefault": 15,
+      "audienceBase": 300
+    },
+    "1day": {
+      "rounds": 3,
+      "startBudget": 3000,
+      "ticketPriceDefault": 20,
+      "audienceBase": 600
+    },
+    "2day": {
+      "rounds": 3,
+      "startBudget": 5000,
+      "ticketPriceDefault": 25,
+      "audienceBase": 800
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add presets for club, party, 1day and 2day modes to default v1/v2 rulesets
- specify rounds, starting budgets, default ticket price and audience base per mode

## Testing
- `php tests/admin_endpoints_test.php`
- `php tests/admin_user_management_test.php`
- `php tests/require_admin_allows_admin.php`
- `php tests/require_admin_blocks_non_admin.php`
- `php tests/require_session_accepts_cookie.php`
- `php tests/require_session_accepts_redirect_header.php`


------
https://chatgpt.com/codex/tasks/task_e_689f304804488320bba254337207f5ce