### PR TITLE
feat: add basic AI turn

### DIFF
--- a/api/act.php
+++ b/api/act.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 $smarty = require __DIR__ . '/../src/bootstrap.php';
 
 require_once __DIR__ . '/update_game.php';
+require_once __DIR__ . '/_game.php';
 require_once __DIR__ . '/../db.php';
 
 header('Content-Type: application/json');
@@ -183,6 +184,12 @@ try {
     $new_state = apply_action($state, $action, $rules);
     $new_state['version'] = $state['version'] + 1;
     update_game_state($pdo, $game_id, $expected_version, $new_state);
+    if (!empty($new_state['ai_enabled'])) {
+        $ai_state = apply_ai_turn($pdo, $game_id, $rules);
+        if (is_array($ai_state)) {
+            $new_state = $ai_state;
+        }
+    }
     echo json_encode(['state' => $new_state], JSON_UNESCAPED_UNICODE);
 } catch (RuntimeException $e) {
     if ($e->getMessage() === 'Version mismatch') {


### PR DESCRIPTION
## Summary
- add `apply_ai_turn` helper that plays a random valid card or advances phase, updating AI hand/deck
- call AI turn from action endpoint when `ai_enabled` is set

## Testing
- `php -l api/_game.php`
- `php -l api/act.php`
- `php tests/admin_endpoints_test.php` *(fails: Failed opening required '/workspace/dark-promoters/src/../vendor/autoload.php')*
- `php tests/admin_user_management_test.php` *(fails: Failed opening required '/workspace/dark-promoters/src/../vendor/autoload.php')*
- `php tests/require_admin_allows_admin.php`
- `php tests/require_admin_blocks_non_admin.php`
- `php tests/require_session_accepts_cookie.php`
- `php tests/require_session_accepts_redirect_header.php`
- `php tests/unknown_mode_scoring_test.php`


------
https://chatgpt.com/codex/tasks/task_e_689f3873ecc88320babc7315da22a573