### PR TITLE
Add AI opponent option

### DIFF
--- a/api/matches_start.php
+++ b/api/matches_start.php
@@ -63,7 +63,7 @@ try {
     }
 
     $initial_state = [];
-    $result = create_game($pdo, $user['id'], $ruleset_id, $initial_state, $match_id);
+    $result = create_game($pdo, $user['id'], $ruleset_id, $initial_state, $match_id, false);
     $game_id = $result['game_id'];
 
     $insert = $pdo->prepare('INSERT INTO game_players (game_id, user_id) VALUES (:gid, :uid)');

--- a/api/new_game.php
+++ b/api/new_game.php
@@ -22,6 +22,7 @@ $ruleset_id = $input['ruleset_id'] ?? 'default.latest';
 $initial_state = $input['state'] ?? [];
 $match_id = isset($input['match_id']) ? (int)$input['match_id'] : null;
 $mode = isset($input['mode']) ? (string)$input['mode'] : '';
+$vs_ai = !empty($input['vs_ai']);
 
 if ($host_user_id <= 0 || !is_array($initial_state) || $mode === '') {
     http_response_code(400);
@@ -40,7 +41,7 @@ try {
 
     $pdo = db();
     $pdo->beginTransaction();
-    $result = create_game($pdo, $host_user_id, $ruleset_id, $initial_state, $match_id);
+    $result = create_game($pdo, $host_user_id, $ruleset_id, $initial_state, $match_id, $vs_ai);
     $pdo->commit();
     echo json_encode($result, JSON_UNESCAPED_UNICODE);
 } catch (RuntimeException $e) {

--- a/public/game.php
+++ b/public/game.php
@@ -2,4 +2,5 @@
 declare(strict_types=1);
 require __DIR__ . '/../src/page.php';
 
-render_page('game.tpl');
+$vs_ai = isset($_GET['vs_ai']) ? '1' : '0';
+render_page('game.tpl', ['vs_ai' => $vs_ai]);


### PR DESCRIPTION
## Summary
- allow new games to specify `vs_ai` flag
- initialize AI state and starting hand when creating games
- enable launching games vs AI via `game.php?vs_ai=1`

## Testing
- `php tests/admin_endpoints_test.php`
- `php tests/admin_user_management_test.php`
- `php tests/require_admin_allows_admin.php`
- `php tests/require_admin_blocks_non_admin.php; echo`
- `php tests/require_session_accepts_cookie.php; echo`
- `php tests/require_session_accepts_redirect_header.php`
- `php tests/unknown_mode_scoring_test.php`


------
https://chatgpt.com/codex/tasks/task_e_689f39e408808320936e765226204ff0