### PR TITLE
Support AI player counts and multi-AI game setup

### DIFF
--- a/api/new_game.php
+++ b/api/new_game.php
@@ -22,7 +22,7 @@ $ruleset_id = $input['ruleset_id'] ?? 'default.latest';
 $initial_state = $input['state'] ?? [];
 $match_id = isset($input['match_id']) ? (int)$input['match_id'] : null;
 $mode = isset($input['mode']) ? (string)$input['mode'] : '';
-$vs_ai = !empty($input['vs_ai']);
+$ai_count = isset($input['ai_count']) ? (int)$input['ai_count'] : (!empty($input['vs_ai']) ? 1 : 0);
 
 if ($host_user_id <= 0 || !is_array($initial_state) || $mode === '') {
     http_response_code(400);
@@ -41,7 +41,7 @@ try {
 
     $pdo = db();
     $pdo->beginTransaction();
-    $result = create_game($pdo, $host_user_id, $ruleset_id, $initial_state, $match_id, $vs_ai);
+    $result = create_game($pdo, $host_user_id, $ruleset_id, $initial_state, $match_id, $ai_count);
     $pdo->commit();
     echo json_encode($result, JSON_UNESCAPED_UNICODE);
 } catch (RuntimeException $e) {


### PR DESCRIPTION
## Summary
- enforce presence of both human and AI players when starting a match
- create games with a configurable number of AI players
- pass AI player count through new game endpoint

## Testing
- `composer install`
- `for f in tests/*_test.php tests/require_*.php; do echo "Running $f"; php $f; done`

------
https://chatgpt.com/codex/tasks/task_e_689f4ed0f6908320bd5ad6231e31267f