### PR TITLE
Handle empty or invalid match list response

### DIFF
--- a/public/matches.js
+++ b/public/matches.js
@@ -10,18 +10,43 @@ document.addEventListener('DOMContentLoaded', () => {
   const nameInput = document.getElementById('match_name');
   const maxInput = document.getElementById('max_players');
   const creatorTpl = document.getElementById('creator_actions_template');
+  const errorDiv = document.getElementById('matches_error');
   let currentUser = null;
+
+  function showError(err) {
+    console.error(err);
+    if (errorDiv) {
+      errorDiv.textContent = String(err);
+    }
+  }
 
   async function loadMatches() {
     try {
       const res = await fetch('/api/matches_list.php', {
         headers: { 'Authorization': `Bearer ${token}` }
       });
-      const json = await res.json();
+      if (!res.ok) {
+        showError(await res.text());
+        return;
+      }
+      const text = await res.text();
+      if (!text) {
+        return;
+      }
+      let json;
+      try {
+        json = JSON.parse(text);
+      } catch (err) {
+        showError(err);
+        return;
+      }
       currentUser = json.user_id;
+      if (errorDiv) {
+        errorDiv.textContent = '';
+      }
       render(json.matches || []);
     } catch (err) {
-      console.error(err);
+      showError(err);
     }
   }
 
@@ -55,7 +80,7 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             loadMatches();
           } catch (err) {
-            console.error(err);
+            showError(err);
           }
         });
         tdActions.appendChild(joinBtn);
@@ -79,7 +104,7 @@ document.addEventListener('DOMContentLoaded', () => {
               });
               loadMatches();
             } catch (err) {
-              console.error(err);
+              showError(err);
             }
           });
         } else {
@@ -98,7 +123,7 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             loadMatches();
           } catch (err) {
-            console.error(err);
+            showError(err);
           }
         });
         tdActions.appendChild(frag);
@@ -126,7 +151,7 @@ document.addEventListener('DOMContentLoaded', () => {
       nameInput.value = '';
       loadMatches();
     } catch (err) {
-      console.error(err);
+      showError(err);
     }
   });
 

--- a/templates/matches.tpl
+++ b/templates/matches.tpl
@@ -15,6 +15,7 @@
         <button type="submit" class="btn btn-primary w-100" data-i18n="create_match_button">Create Match</button>
       </div>
     </form>
+    <div id="matches_error" class="text-danger mb-3"></div>
     <table class="table table-dark table-striped">
       <thead>
         <tr>


### PR DESCRIPTION
## Summary
- Improve match list loading to handle HTTP errors, empty responses, and invalid JSON
- Show any loading errors directly in the matches UI

## Testing
- `php tests/admin_endpoints_test.php` *(fails: Failed opening required '/workspace/dark-promoters/src/../vendor/autoload.php')*
- `for f in tests/*.php; do echo "Running $f"; php "$f" >/tmp/test.log && tail -n 20 /tmp/test.log; done`


------
https://chatgpt.com/codex/tasks/task_e_689f98076844832093397ffd8b1524a1