### PR TITLE
Handle errors in matches list endpoint

### DIFF
--- a/api/matches_list.php
+++ b/api/matches_list.php
@@ -3,47 +3,54 @@
 
 declare(strict_types=1);
 
-$smarty = require __DIR__ . '/../src/bootstrap.php';
-
-require_once __DIR__ . '/_auth.php';
-require_once __DIR__ . '/../db.php';
-
 header('Content-Type: application/json');
 
-$pdo = db();
-$user = require_session($pdo);
+try {
+    $smarty = require __DIR__ . '/../src/bootstrap.php';
 
-$stmt = $pdo->query(
-    "SELECT m.id AS match_id, m.name, m.max_players, m.creator_id, mp.user_id, mp.username AS ai_username, mp.is_ai, u.username
-     FROM matches m
-     LEFT JOIN match_players mp ON mp.match_id = m.id
-     LEFT JOIN users u ON mp.user_id = u.id
-     WHERE m.status = 'waiting'
-     ORDER BY m.id, mp.joined_at"
-);
+    require_once __DIR__ . '/_auth.php';
+    require_once __DIR__ . '/../db.php';
 
-$matches = [];
-while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-    $id = (int)$row['match_id'];
-    if (!isset($matches[$id])) {
-        $matches[$id] = [
-            'id' => $id,
-            'name' => $row['name'],
-            'max_players' => (int)$row['max_players'],
-            'creator_id' => (int)$row['creator_id'],
-            'players' => [],
-        ];
-    }
-    if ($row['user_id'] !== null || $row['ai_username'] !== null) {
-        $player = [
-            'username' => $row['user_id'] !== null ? $row['username'] : $row['ai_username'],
-            'is_ai' => (bool)$row['is_ai'],
-        ];
-        if ($row['user_id'] !== null) {
-            $player['id'] = (int)$row['user_id'];
+    $pdo = db();
+    $user = require_session($pdo);
+
+    $stmt = $pdo->query(
+        "SELECT m.id AS match_id, m.name, m.max_players, m.creator_id, mp.user_id, mp.username AS ai_username, mp.is_ai, u.username
+         FROM matches m
+         LEFT JOIN match_players mp ON mp.match_id = m.id
+         LEFT JOIN users u ON mp.user_id = u.id
+         WHERE m.status = 'waiting'
+         ORDER BY m.id, mp.joined_at"
+    );
+
+    $matches = [];
+    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        $id = (int)$row['match_id'];
+        if (!isset($matches[$id])) {
+            $matches[$id] = [
+                'id' => $id,
+                'name' => $row['name'],
+                'max_players' => (int)$row['max_players'],
+                'creator_id' => (int)$row['creator_id'],
+                'players' => [],
+            ];
         }
-        $matches[$id]['players'][] = $player;
+        if ($row['user_id'] !== null || $row['ai_username'] !== null) {
+            $player = [
+                'username' => $row['user_id'] !== null ? $row['username'] : $row['ai_username'],
+                'is_ai' => (bool)$row['is_ai'],
+            ];
+            if ($row['user_id'] !== null) {
+                $player['id'] = (int)$row['user_id'];
+            }
+            $matches[$id]['players'][] = $player;
+        }
     }
+
+    echo json_encode(['user_id' => $user['id'], 'matches' => array_values($matches)], JSON_UNESCAPED_UNICODE);
+} catch (Throwable $e) {
+    http_response_code(500);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => $e->getMessage()]);
 }
 
-echo json_encode(['user_id' => $user['id'], 'matches' => array_values($matches)], JSON_UNESCAPED_UNICODE);


### PR DESCRIPTION
## Summary
- ensure `api/matches_list.php` always returns JSON and handles exceptions gracefully

## Testing
- `php -l api/matches_list.php`
- `for f in tests/*.php; do php $f; done`


------
https://chatgpt.com/codex/tasks/task_e_689f98e1d92c83208f82637560698645