### PR TITLE
Log errors when adding AI

### DIFF
--- a/api/matches_add_ai.php
+++ b/api/matches_add_ai.php
@@ -70,7 +70,13 @@ try {
     if ($pdo->inTransaction()) {
         $pdo->rollBack();
     }
+    error_log('matches_add_ai: ' . $e->getMessage());
+    error_log($e->getTraceAsString());
     http_response_code(500);
-    echo json_encode(['error' => 'server error'], JSON_UNESCAPED_UNICODE);
+    $response = ['error' => 'server error'];
+    if (getenv('APP_ENV') === 'development') {
+        $response['message'] = $e->getMessage();
+    }
+    echo json_encode($response, JSON_UNESCAPED_UNICODE);
 }
 


### PR DESCRIPTION
## Summary
- log exception message and stack trace when adding an AI player
- show detailed error message in JSON when APP_ENV=development

## Testing
- `php -l api/matches_add_ai.php`
- `for f in tests/*.php; do echo "Running $f"; php "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_68a05fb007888320b012c8e14cd59aaa