### PR TITLE
Add user_id column for AI player insertion

### DIFF
--- a/api/matches_add_ai.php
+++ b/api/matches_add_ai.php
@@ -62,7 +62,10 @@ try {
     }
 
     $aiName = 'AI Bot';
-    $insert = $pdo->prepare('INSERT INTO match_players (match_id, username, is_ai) VALUES (:mid, :name, 1)');
+    $insert = $pdo->prepare(
+        'INSERT INTO match_players (match_id, user_id, username, is_ai)
+         VALUES (:mid, NULL, :name, 1)'
+    );
     $insert->execute([':mid' => $match_id, ':name' => $aiName]);
     $pdo->commit();
     echo json_encode(['added' => true], JSON_UNESCAPED_UNICODE);


### PR DESCRIPTION
## Summary
- include `user_id` field when inserting AI players into `match_players`

## Testing
- `php -l api/matches_add_ai.php`
- `for f in tests/*_test.php; do php "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_68a063a0503083209ad13da22205003f